### PR TITLE
added tests for anyOf, allOf and oneOf

### DIFF
--- a/test/contractTests-GET-allOf.js
+++ b/test/contractTests-GET-allOf.js
@@ -1,0 +1,221 @@
+const assert = require('chai').assert
+const newman = require('newman')
+const fs = require('fs')
+const PostmanMockBuilder = require('@jordanwalsh23/postman-mock-builder')
+
+describe('Postman Contract Test Suite - GET AllOf Requests', () => {
+  let GET_SCHEMA = './test/schemas/sample-product-GET-schema-allOf.json'
+
+  describe('TEST001 - GET Valid Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3555
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST001'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          test: "test",
+          id: '1234',
+          name: 'Name',
+          description: 'Description',
+          model: 'Model',
+          sku: 'SKU',
+          cost: 445,
+          imageUrl: 'image-url'
+        }
+      ]
+
+      let state = test001MockServer.addState('A product exists in the database')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3555/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3555'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done('Tests Failed')
+            } else {
+              done()
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+  describe('TEST002 - GET Invalid Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3556
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST002'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          id: '1234',
+          name: 'Name',
+          description: 'Description',
+          model: 'Model',
+          sku: 'SKU',
+          cost: 445,
+          imageUrl: 'image-url'
+        }
+      ]
+
+      let state = test001MockServer.addState('A product exists in the database')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3556/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3556'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done();
+            } else {
+              done('Expected this test to fail.')
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+})

--- a/test/contractTests-GET-anyOf.js
+++ b/test/contractTests-GET-anyOf.js
@@ -1,0 +1,422 @@
+const assert = require('chai').assert
+const newman = require('newman')
+const fs = require('fs')
+const PostmanMockBuilder = require('@jordanwalsh23/postman-mock-builder')
+
+describe('Postman Contract Test Suite - GET OneOf Requests', () => {
+  let GET_SCHEMA = './test/schemas/sample-product-GET-schema-anyOf.json'
+
+  describe('TEST001 - GET Full Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3555
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST001'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          id: '1234',
+          name: 'Name',
+          description: 'Description',
+          model: 'Model',
+          sku: 'SKU',
+          cost: 445,
+          imageUrl: 'image-url'
+        }
+      ]
+
+      let state = test001MockServer.addState('Return the full product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3555/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3555'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done('Tests Failed')
+            } else {
+              done()
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+  describe('TEST002 - GET Partial Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3556
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST002'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          test:"test"
+        }
+      ]
+
+      let state = test001MockServer.addState('Return a partial product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3556/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3556'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done('Tests Failed')
+            } else {
+              done()
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+  describe('TEST003 - GET Neither Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3557
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST003'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          foo:"bar"
+        }
+      ]
+
+      let state = test001MockServer.addState('Return a partial product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3557/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3557'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done()
+            } else {
+              done('Expected this test to fail.')
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+  describe('TEST004 - GET Both Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3558
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST004'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          test: 'test',
+          id: '1234',
+          name: 'Name',
+          description: 'Description',
+          model: 'Model',
+          sku: 'SKU',
+          cost: 445,
+          imageUrl: 'image-url'
+        }
+      ]
+
+      let state = test001MockServer.addState('Return a partial product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3558/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3558'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done("Test failed.")
+            } else {
+              done()
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+})

--- a/test/contractTests-GET-oneOf.js
+++ b/test/contractTests-GET-oneOf.js
@@ -1,0 +1,422 @@
+const assert = require('chai').assert
+const newman = require('newman')
+const fs = require('fs')
+const PostmanMockBuilder = require('@jordanwalsh23/postman-mock-builder')
+
+describe('Postman Contract Test Suite - GET OneOf Requests', () => {
+  let GET_SCHEMA = './test/schemas/sample-product-GET-schema-oneOf.json'
+
+  describe('TEST001 - GET Full Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3555
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST001'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          id: '1234',
+          name: 'Name',
+          description: 'Description',
+          model: 'Model',
+          sku: 'SKU',
+          cost: 445,
+          imageUrl: 'image-url'
+        }
+      ]
+
+      let state = test001MockServer.addState('Return the full product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3555/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3555'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done('Tests Failed')
+            } else {
+              done()
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+  describe('TEST002 - GET Partial Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3556
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST002'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          test:"test"
+        }
+      ]
+
+      let state = test001MockServer.addState('Return a partial product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3556/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3556'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done('Tests Failed')
+            } else {
+              done()
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+  describe('TEST003 - GET Neither Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3557
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST003'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          foo:"bar"
+        }
+      ]
+
+      let state = test001MockServer.addState('Return a partial product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3557/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3557'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done()
+            } else {
+              done('Expected this test to fail.')
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+  describe('TEST004 - GET Both Product Response', () => {
+    let test001MockServer = null
+    before('setup mock server', done => {
+      const PORT = 3558
+
+      test001MockServer = PostmanMockBuilder.create({
+        apiVersion: 'TEST004'
+      })
+
+      test001MockServer
+        .addState('API Schema')
+        .addRequest({
+          method: 'GET',
+          path: '/schema'
+        })
+        .addResponse({
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.parse(fs.readFileSync(GET_SCHEMA, 'utf-8').toString())
+        })
+
+      let test001response = [
+        {
+          test: 'test',
+          id: '1234',
+          name: 'Name',
+          description: 'Description',
+          model: 'Model',
+          sku: 'SKU',
+          cost: 445,
+          imageUrl: 'image-url'
+        }
+      ]
+
+      let state = test001MockServer.addState('Return a partial product schema')
+
+      state
+        .addRequest({
+          method: 'GET',
+          path: '/api/products'
+        })
+        .addResponse({
+          status: 200,
+          body: test001response
+        })
+
+      test001MockServer.start(PORT)
+      done()
+    })
+
+    it('runs a contract test', done => {
+      newman
+        .run({
+          collection: require('../src/Contract Test Generator.postman_collection.json'),
+          environment: require('../src/Contract Test Environment.postman_environment.json'),
+          envVar: [
+            {
+              key: 'env-schemaUrl',
+              value: 'http://localhost:3558/schema'
+            },
+            {
+              key: 'env-server',
+              value: 'http://localhost:3558'
+            }
+          ]
+        })
+        .on('start', function (err, args) {
+          // on start of run, log to console
+          console.log('running a collection...')
+        })
+        .on('done', function (err, summary) {
+          if (err || summary.error) {
+            console.error('collection run encountered an error.')
+            done(err)
+          } else {
+            console.log('collection run completed.')
+            if (
+              summary.run &&
+              summary.run.failures &&
+              summary.run.failures.length > 0
+            ) {
+              summary.run.failures.forEach(failure => {
+                console.log(
+                  'Test: ' +
+                    failure.error.test +
+                    ' - result: ' +
+                    failure.error.message
+                )
+              })
+
+              done()
+            } else {
+              done('Expected this test to fail.')
+            }
+          }
+        })
+    })
+
+    after('finish', done => {
+      console.log('stopping server')
+      test001MockServer.stop()
+      done()
+    })
+  })
+
+})

--- a/test/schemas/sample-product-GET-schema-allOf.json
+++ b/test/schemas/sample-product-GET-schema-allOf.json
@@ -1,0 +1,122 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.3",
+    "title": "Test Products API"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3555",
+      "description": "Test Server"
+    },{
+      "url": "http://localhost:3556",
+      "description": "Test Server"
+    }
+  ],
+  "paths": {
+    "/api/products": {
+      "get": {
+        "summary": "Returns a list of products from the database",
+        "operationId": "getProducts",
+        "tags": [
+          "Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of current products",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductsList"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ProductsList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ViewProduct"
+        }
+      },
+      "ViewProduct": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "test"
+            ],
+            "properties": {
+              "test": {
+                "type": "string",
+                "example": "test",
+                "description": "Test field for testing"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/ViewProductSchema"
+          }
+        ]
+      },
+      "ViewProductSchema": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "model",
+          "sku",
+          "cost"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "description": "The ID of the Product",
+            "example": "a1805cde-f34f-4945-9fec-3e096fef4bdd"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the Product",
+            "example": "Bose Noise Cancelling Over-Ear Headphones 700 (Black)",
+            "minLength": 3
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the Product",
+            "example": "- 11 levels of noise cancelling\n- Google Assistant and Amazon Alexa built in\n- 20 hours of battery life\n"
+          },
+          "model": {
+            "type": "string",
+            "description": "The model number of the Product",
+            "example": "794297-0100"
+          },
+          "sku": {
+            "type": "string",
+            "description": "The SKU of the Product",
+            "example": "394807"
+          },
+          "cost": {
+            "description": "The cost of the Product",
+            "type": "number",
+            "format": "float",
+            "example": 445
+          },
+          "imageUrl": {
+            "type": "string",
+            "description": "The URL to the image of the Product",
+            "format": "url",
+            "minLength": 3,
+            "example": "https://cdn.shopify.com/s/files/1/0024/9803/5810/products/394807-Product-0-I_d1664990-4dfb-462f-bb93-2fb469ed7d5d_800x800.jpg"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/schemas/sample-product-GET-schema-anyOf.json
+++ b/test/schemas/sample-product-GET-schema-anyOf.json
@@ -1,0 +1,128 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.3",
+    "title": "Test Products API"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3555",
+      "description": "Test Server"
+    },{
+      "url": "http://localhost:3556",
+      "description": "Test Server"
+    },{
+      "url": "http://localhost:3557",
+      "description": "Test Server"
+    },{
+      "url": "http://localhost:3558",
+      "description": "Test Server"
+    }
+  ],
+  "paths": {
+    "/api/products": {
+      "get": {
+        "summary": "Returns a list of products from the database",
+        "operationId": "getProducts",
+        "tags": [
+          "Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of current products",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductsList"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ProductsList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ViewProduct"
+        }
+      },
+      "ViewProduct": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "test"
+            ],
+            "properties": {
+              "test": {
+                "type": "string",
+                "example": "test",
+                "description": "Test field for testing"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/ViewProductSchema"
+          }
+        ]
+      },
+      "ViewProductSchema": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "model",
+          "sku",
+          "cost"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "description": "The ID of the Product",
+            "example": "a1805cde-f34f-4945-9fec-3e096fef4bdd"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the Product",
+            "example": "Bose Noise Cancelling Over-Ear Headphones 700 (Black)",
+            "minLength": 3
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the Product",
+            "example": "- 11 levels of noise cancelling\n- Google Assistant and Amazon Alexa built in\n- 20 hours of battery life\n"
+          },
+          "model": {
+            "type": "string",
+            "description": "The model number of the Product",
+            "example": "794297-0100"
+          },
+          "sku": {
+            "type": "string",
+            "description": "The SKU of the Product",
+            "example": "394807"
+          },
+          "cost": {
+            "description": "The cost of the Product",
+            "type": "number",
+            "format": "float",
+            "example": 445
+          },
+          "imageUrl": {
+            "type": "string",
+            "description": "The URL to the image of the Product",
+            "format": "url",
+            "minLength": 3,
+            "example": "https://cdn.shopify.com/s/files/1/0024/9803/5810/products/394807-Product-0-I_d1664990-4dfb-462f-bb93-2fb469ed7d5d_800x800.jpg"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/schemas/sample-product-GET-schema-oneOf.json
+++ b/test/schemas/sample-product-GET-schema-oneOf.json
@@ -1,0 +1,128 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.3",
+    "title": "Test Products API"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3555",
+      "description": "Test Server"
+    },{
+      "url": "http://localhost:3556",
+      "description": "Test Server"
+    },{
+      "url": "http://localhost:3557",
+      "description": "Test Server"
+    },{
+      "url": "http://localhost:3558",
+      "description": "Test Server"
+    }
+  ],
+  "paths": {
+    "/api/products": {
+      "get": {
+        "summary": "Returns a list of products from the database",
+        "operationId": "getProducts",
+        "tags": [
+          "Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of current products",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductsList"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ProductsList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ViewProduct"
+        }
+      },
+      "ViewProduct": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "test"
+            ],
+            "properties": {
+              "test": {
+                "type": "string",
+                "example": "test",
+                "description": "Test field for testing"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/ViewProductSchema"
+          }
+        ]
+      },
+      "ViewProductSchema": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "model",
+          "sku",
+          "cost"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "description": "The ID of the Product",
+            "example": "a1805cde-f34f-4945-9fec-3e096fef4bdd"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the Product",
+            "example": "Bose Noise Cancelling Over-Ear Headphones 700 (Black)",
+            "minLength": 3
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the Product",
+            "example": "- 11 levels of noise cancelling\n- Google Assistant and Amazon Alexa built in\n- 20 hours of battery life\n"
+          },
+          "model": {
+            "type": "string",
+            "description": "The model number of the Product",
+            "example": "794297-0100"
+          },
+          "sku": {
+            "type": "string",
+            "description": "The SKU of the Product",
+            "example": "394807"
+          },
+          "cost": {
+            "description": "The cost of the Product",
+            "type": "number",
+            "format": "float",
+            "example": 445
+          },
+          "imageUrl": {
+            "type": "string",
+            "description": "The URL to the image of the Product",
+            "format": "url",
+            "minLength": 3,
+            "example": "https://cdn.shopify.com/s/files/1/0024/9803/5810/products/394807-Product-0-I_d1664990-4dfb-462f-bb93-2fb469ed7d5d_800x800.jpg"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
These tests ensure support for using schemas that have `anyOf`, `oneOf` or `allOf` referenced as part of the schema definitions.

One of the concerns stated for the Contract Test Generator was that it doesn't respect these elements, however these tests show that the tooling works as expected when any of these elements are used.