### PR TITLE
Fix missing schema

### DIFF
--- a/src/Contract Test Generator.postman_collection.json
+++ b/src/Contract Test Generator.postman_collection.json
@@ -5,1509 +5,1511 @@
 		"description": "This collection will automatically generate a series of tests against an OpenAPI3 definition that is within your API Builder in Postman.\n\n## Getting Started\n\nRead the documentation on the [Contract Testing Public Workspace](https://postman.postman.co/workspace/0bc7d76d-b582-45ba-b216-5da2c1d174a0) to get started.\n\n## Running this collection\n\nFirstly, make sure you have set up your environment variables by forking [this environment](https://postman.postman.co/workspace/Contract-Test-Generator~0bc7d76d-b582-45ba-b216-5da2c1d174a0/environment/18354885-1125d62a-154a-45a6-8b04-73073e8e4d16). Once completed, this collection can be run using the Postman collection runner or from Newman.\n\n## Support\n\nThis collection is maintained in GitHub by the Postman Solutions Engineering team. Please post an issue directly in [this GitHub project](https://github.com/postman-solutions-eng/postman-contract-test-generator) if you need support.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
-  "item": [
-    {
-      "name": "API Validation",
-      "item": [
-        {
-          "name": "Initialize",
-          "item": [
-            {
-              "name": "Cleanup Previous Run",
-              "event": [
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "// See https://blog.postman.com/2019/05/28/pro-tip-dynamically-unset-postman-environment-variables/\r",
-                      "// for more details on what we're doing here. \r",
-                      "\r",
-                      "cleanupCollectionVariables();\r",
-                      "\r",
-                      "function cleanupCollectionVariables() {\r",
-                      "    const clean = _.keys(pm.collectionVariables.toObject());\r",
-                      "\r",
-                      "    _.each(clean, (arrItem) => {\r",
-                      "        pm.collectionVariables.unset(arrItem);\r",
-                      "    });\r",
-                      "}"
-                    ],
-                    "type": "text/javascript"
-                  }
-                },
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "https://postman-echo.com/delay/0",
-                  "protocol": "https",
-                  "host": [
-                    "postman-echo",
-                    "com"
-                  ],
-                  "path": [
-                    "delay",
-                    "0"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Initialize",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const providedSchema = pm.environment.get('env-schema');\r",
-                      "const providedSchemaUrl = pm.environment.get('env-schemaUrl');\r",
-                      "\r",
-                      "if(providedSchemaUrl) {\r",
-                      "    postman.setNextRequest(\"Get Schema From URL\");\r",
-                      "} else if(providedSchema) {\r",
-                      "    let success = true;\r",
-                      "    try{\r",
-                      "        const yaml = pm.environment.get('env-jsonToYaml');\r",
-                      "        (new Function(yaml))();\r",
-                      "\r",
-                      "        const schema = jsyaml.load(providedSchema);\r",
-                      "        pm.collectionVariables.set('coll-schema', JSON.stringify(schema));\r",
-                      "        postman.setNextRequest('Get API Base Url');\r",
-                      "    }\r",
-                      "    catch(err){\r",
-                      "        console.log(err);\r",
-                      "        success = false;\r",
-                      "        postman.setNextRequest(null);\r",
-                      "    }\r",
-                      "\r",
-                      "    pm.test('Successfully converted provided schema', function(){\r",
-                      "        pm.expect(success).to.be.true;\r",
-                      "    });    \r",
-                      "} else {\r",
-                      "    postman.setNextRequest(\"Validate API In Workspace\");\r",
-                      "}"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "https://postman-echo.com/delay/0",
-                  "protocol": "https",
-                  "host": [
-                    "postman-echo",
-                    "com"
-                  ],
-                  "path": [
-                    "delay",
-                    "0"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Get Schema from URL",
-          "item": [
-            {
-              "name": "Get Schema From URL",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "let responseSchema = pm.response.text();",
-                      "",
-                      "if(responseSchema.length != 0) {",
-                      "    let success = true;",
-                      "    try{",
-                      "        const yaml = pm.environment.get('env-jsonToYaml');",
-                      "        (new Function(yaml))();",
-                      "",
-                      "        const schema = jsyaml.load(responseSchema);",
-                      "        pm.collectionVariables.set('coll-schema', JSON.stringify(schema));",
-                      "        postman.setNextRequest('Get API Base Url');",
-                      "    }",
-                      "    catch(err){",
-                      "        console.log(err);",
-                      "        success = false;",
-                      "        postman.setNextRequest(null);",
-                      "    }",
-                      "",
-                      "    pm.test('Successfully converted provided schema', function(){",
-                      "        pm.expect(success).to.be.true;",
-                      "    }); ",
-                      "} else {",
-                      "    console.log(\"Error retrieving schema from URL - \" + pm.environment.get(\"env-schemaUrl\"));",
-                      "    postman.setNextRequest(null);",
-                      "}",
-                      "",
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "method": "GET",
-                "header": [],
-                "url": {
-                  "raw": "{{env-schemaUrl}}",
-                  "host": [
-                    "{{env-schemaUrl}}"
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Get Schema from Postman",
-          "item": [
-            {
-              "name": "Validate API In Workspace",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const minApiCount = Number(pm.environment.get('env-minApiCount'));\r",
-                      "const maxApiCount = Number(pm.environment.get('env-maxApiCount'));\r",
-                      "const jsonData = pm.response.json();\r",
-                      "\r",
-                      "pm.test(`Workspace API count is between ${minApiCount} and ${maxApiCount}. (Count: ${jsonData.apis.length})`, function () {    \r",
-                      "    pm.expect(jsonData.apis.length).to.be.at.least(minApiCount);    \r",
-                      "    pm.expect(jsonData.apis.length).to.be.at.most(maxApiCount);\r",
-                      "});\r",
-                      "\r",
-                      "let apiIds = [];\r",
-                      "_.forEach(jsonData.apis, function(api){\r",
-                      "    apiIds.push(api.id);\r",
-                      "});\r",
-                      "\r",
-                      "pm.collectionVariables.set('coll-apiIds', JSON.stringify(apiIds));"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "X-Api-Key",
-                    "value": "{{env-apiKey}}",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "https://api.getpostman.com/apis?workspace={{env-workspaceId}}",
-                  "protocol": "https",
-                  "host": [
-                    "api",
-                    "getpostman",
-                    "com"
-                  ],
-                  "path": [
-                    "apis"
-                  ],
-                  "query": [
-                    {
-                      "key": "workspace",
-                      "value": "{{env-workspaceId}}"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Get Current API Version",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json();\r",
-                      "\r",
-                      "pm.test('API has one or more versions', function(){\r",
-                      "    pm.expect(jsonData).to.have.property('versions').and.to.be.an('array');\r",
-                      "    pm.expect(jsonData.versions.length).to.be.above(0);\r",
-                      "});\r",
-                      "\r",
-                      "const version = jsonData.versions[0];\r",
-                      "pm.collectionVariables.set('coll-versionId', version.id);"
-                    ],
-                    "type": "text/javascript"
-                  }
-                },
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "let apiIds = pm.collectionVariables.get('coll-apiIds');\r",
-                      "if(apiIds){\r",
-                      "    apiIds = JSON.parse(apiIds);\r",
-                      "    const apiId = apiIds.pop();\r",
-                      "\r",
-                      "    pm.collectionVariables.set('coll-apiId', apiId);\r",
-                      "    pm.collectionVariables.set('coll-apiIds', JSON.stringify(apiIds));\r",
-                      "}\r",
-                      "else {\r",
-                      "    pm.request.url = 'https://postman-echo.com/delay/0'\r",
-                      "    pm.request.name = 'No APIs found in the workspace. Skipping execution';\r",
-                      "    postman.setNextRequest(null);\r",
-                      "}"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "X-Api-Key",
-                    "value": "{{env-apiKey}}",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "https://api.getpostman.com/apis/:apiId/versions",
-                  "protocol": "https",
-                  "host": [
-                    "api",
-                    "getpostman",
-                    "com"
-                  ],
-                  "path": [
-                    "apis",
-                    ":apiId",
-                    "versions"
-                  ],
-                  "query": [
-                    {
-                      "key": null,
-                      "value": "",
-                      "disabled": true
-                    }
-                  ],
-                  "variable": [
-                    {
-                      "key": "apiId",
-                      "value": "{{coll-apiId}}"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Get Current API Schema",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const jsonData = pm.response.json();\r",
-                      "\r",
-                      "pm.test('Has schema for current version', function(){\r",
-                      "    pm.expect(jsonData).to.have.property('version');\r",
-                      "    pm.expect(jsonData.version).to.have.property('schema').and.to.be.an('array');\r",
-                      "    pm.expect(jsonData.version.schema.length).to.be.above(0);\r",
-                      "\r",
-                      "    pm.collectionVariables.set('coll-schemaId', jsonData.version.schema[0]);\r",
-                      "});"
-                    ],
-                    "type": "text/javascript"
-                  }
-                },
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      ""
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "X-Api-Key",
-                    "type": "text",
-                    "value": "{{env-apiKey}}"
-                  }
-                ],
-                "url": {
-                  "raw": "https://api.getpostman.com/apis/:apiId/versions/:versionId",
-                  "protocol": "https",
-                  "host": [
-                    "api",
-                    "getpostman",
-                    "com"
-                  ],
-                  "path": [
-                    "apis",
-                    ":apiId",
-                    "versions",
-                    ":versionId"
-                  ],
-                  "query": [
-                    {
-                      "key": null,
-                      "value": "",
-                      "disabled": true
-                    }
-                  ],
-                  "variable": [
-                    {
-                      "key": "apiId",
-                      "value": "{{coll-apiId}}"
-                    },
-                    {
-                      "key": "versionId",
-                      "value": "{{coll-versionId}}"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
-              "name": "Get API Schema",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "try {\r",
-                      "    const jsonData = pm.response.json();\r",
-                      "\r",
-                      "    if(jsonData.schema.language.toLowerCase() == 'json'){\r",
-                      "        pm.test('Schema is JSON', function(){\r",
-                      "            pm.expect(1).to.equal(1);\r",
-                      "            pm.collectionVariables.set('coll-schema', jsonData.schema.schema);\r",
-                      "        });\r",
-                      "    }\r",
-                      "    else {\r",
-                      "        pm.test('Schema translates to JSON', function(){\r",
-                      "            try{\r",
-                      "                const yaml = pm.environment.get('env-jsonToYaml');\r",
-                      "                (new Function(yaml))();\r",
-                      "\r",
-                      "                const schema = jsyaml.load(jsonData.schema.schema);\r",
-                      "                pm.collectionVariables.set('coll-schema', JSON.stringify(schema));\r",
-                      "                pm.expect(1).to.equal(1);\r",
-                      "            }\r",
-                      "            catch(err){\r",
-                      "                pm.expect(`${err.name} - ${err.message}`).to.equal(undefined);\r",
-                      "            }    \r",
-                      "        });\r",
-                      "    }\r",
-                      "}\r",
-                      "catch(err) {\r",
-                      "    console.log(err);\r",
-                      "    pm.test('Unable to load schema', function(){\r",
-                      "        pm.expect(0).to.equal(1);\r",
-                      "        postman.setNextRequest(null);\r",
-                      "    })\r",
-                      "}"
-                    ],
-                    "type": "text/javascript"
-                  }
-                }
-              ],
-              "request": {
-                "auth": {
-                  "type": "noauth"
-                },
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "X-Api-Key",
-                    "value": "{{env-apiKey}}",
-                    "type": "text"
-                  }
-                ],
-                "url": {
-                  "raw": "https://api.getpostman.com/apis/:apiId/versions/:apiVersionId/schemas/:schemaId",
-                  "protocol": "https",
-                  "host": [
-                    "api",
-                    "getpostman",
-                    "com"
-                  ],
-                  "path": [
-                    "apis",
-                    ":apiId",
-                    "versions",
-                    ":apiVersionId",
-                    "schemas",
-                    ":schemaId"
-                  ],
-                  "variable": [
-                    {
-                      "key": "apiId",
-                      "value": "{{coll-apiId}}"
-                    },
-                    {
-                      "key": "apiVersionId",
-                      "value": "{{coll-versionId}}"
-                    },
-                    {
-                      "key": "schemaId",
-                      "value": "{{coll-schemaId}}"
-                    }
-                  ]
-                }
-              },
-              "response": []
-            }
-          ]
-        },
-        {
-          "name": "Get API Base Url",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
-                  "const server = pm.environment.get('env-server');\r",
-                  "\r",
-                  "pm.test('Environment has test server defined', function () {\r",
-                  "    pm.expect(server).to.not.be.undefined;\r",
-                  "});\r",
-                  "\r",
-                  "pm.test('Schema has server/baseUrl defined', function () {\r",
-                  "    const servers = schema.servers;\r",
-                  "    pm.expect(servers).to.not.be.undefined;\r",
-                  "    const serverToTest = servers.find(s => s.url.toLowerCase() == server.toLowerCase());\r",
-                  "    pm.expect(serverToTest).to.not.be.undefined;\r",
-                  "\r",
-                  "    pm.expect(serverToTest).to.have.property('url');\r",
-                  "    pm.collectionVariables.set('coll-baseUrl', serverToTest.url);\r",
-                  "});\r",
-                  "\r",
-                  "const runComponentTests = pm.environment.get('env-runComponentTests') == 'true';\r",
-                  "if(!runComponentTests){   \r",
-                  "    const runContractTests = pm.environment.get('env-runContractTests') == 'true';\r",
-                  "    if(runContractTests){\r",
-                  "        postman.setNextRequest('Build Schema Tests');\r",
-                  "    } else {\r",
-                  "        postman.setNextRequest('More APIs to Process?');\r",
-                  "    }   \r",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "https://postman-echo.com/delay/0",
-              "protocol": "https",
-              "host": [
-                "postman-echo",
-                "com"
-              ],
-              "path": [
-                "delay",
-                "0"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Components",
-      "item": [
-        {
-          "name": "Verify Component Adherence",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
-                  "\r",
-                  "const requireParamDescription = Boolean(pm.environment.get('env-requireParamDescription'));\r",
-                  "const requireParamExample = Boolean(pm.environment.get('env-requireParamExample'));\r",
-                  "\r",
-                  "let paramDescriptionMinLength = pm.environment.get('env-paramDescriptionMinLength');\r",
-                  "if (paramDescriptionMinLength) {\r",
-                  "    paramDescriptionMinLength = Number(paramDescriptionMinLength);\r",
-                  "}\r",
-                  "\r",
-                  "let paramDescriptionMaxLength = pm.environment.get('env-paramDesciptionMaxLength');\r",
-                  "if (paramDescriptionMaxLength) {\r",
-                  "    paramDescriptionMaxLength = Number(paramDescriptionMaxLength);\r",
-                  "}\r",
-                  "\r",
-                  "var testedSchemaRefs = [];\r",
-                  "\r",
-                  "if (schema.components.parameters) {\r",
-                  "    for (let prop in schema.components.parameters) {\r",
-                  "        let parameter = schema.components.parameters[prop];\r",
-                  "\r",
-                  "        pm.test(`Parameter '${prop}' starts with a lowercase letter`, function () {\r",
-                  "            pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toLowerCase());\r",
-                  "        });\r",
-                  "\r",
-                  "        if (requireParamDescription) {\r",
-                  "            pm.test(`Parameter '${prop}' has a description between ${paramDescriptionMinLength} and ${paramDescriptionMaxLength} characters`, function () {\r",
-                  "                pm.expect(parameter).to.have.property('description').and.to.be.a('string');\r",
-                  "                pm.expect(parameter.description.length).to.be.at.least(paramDescriptionMinLength);\r",
-                  "                pm.expect(parameter.description.length).to.be.at.most(paramDescriptionMaxLength);\r",
-                  "            });\r",
-                  "        }\r",
-                  "\r",
-                  "        if (requireParamExample) {\r",
-                  "            pm.test(`Parameter '${prop}' has an example`, function () {\r",
-                  "                pm.expect(parameter).to.have.property('schema');\r",
-                  "                pm.expect(parameter.schema).to.have.property('example');\r",
-                  "            });\r",
-                  "        }\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "if (schema.components.schemas) {\r",
-                  "    for (let prop in schema.components.schemas) {\r",
-                  "        pm.test(`Schema '${prop}' begins with an uppercase letter`, function () {\r",
-                  "            pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toUpperCase());\r",
-                  "        });\r",
-                  "\r",
-                  "        const testedSchema = testedSchemaRefs.find(tsr => tsr == prop);\r",
-                  "        if (!testedSchema) {\r",
-                  "            const schemaObject = schema.components.schemas[prop];\r",
-                  "            testSchemaObject(schema, schemaObject, prop);\r",
-                  "            testedSchemaRefs.push(prop);\r",
-                  "        }\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "if (schema.components.responses) {\r",
-                  "    for (let prop in schema.components.responses) {\r",
-                  "        pm.test(`Response '${prop}' begins with an uppercase letter`, function () {\r",
-                  "            pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toUpperCase());\r",
-                  "        });\r",
-                  "\r",
-                  "        if (requireParamDescription) {\r",
-                  "            const response = schema.components.responses[prop];\r",
-                  "            pm.test(`Response '${prop}' has a description between ${paramDescriptionMinLength} and ${paramDescriptionMaxLength} characters`, function () {\r",
-                  "                pm.expect(response).to.have.property('description').and.to.be.a('string');\r",
-                  "                pm.expect(response.description.length).to.be.at.least(paramDescriptionMinLength);\r",
-                  "                pm.expect(response.description.length).to.be.at.most(paramDescriptionMaxLength);\r",
-                  "            });\r",
-                  "        }\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "const runContractTests = pm.environment.get('env-runContractTests') == 'true';\r",
-                  "if (runContractTests) {\r",
-                  "    postman.setNextRequest('Build Schema Tests');\r",
-                  "} else {\r",
-                  "    postman.setNextRequest('More APIs to Process?');\r",
-                  "}\r",
-                  "\r",
-                  "\r",
-                  "function testSchemaObject(schema, object, objectName) {\r",
-                  "    if (object.type && object.type.toLowerCase() == 'object') {\r",
-                  "        if (object.required) {\r",
-                  "            for (let i = 0; i < object.required.length; i++) {\r",
-                  "                const requiredProp = object.required[i];\r",
-                  "                pm.test(`Schema '${objectName}' has required property '${requiredProp}' defined`, function () {\r",
-                  "                    pm.expect(object.properties).to.have.property(requiredProp);\r",
-                  "                });\r",
-                  "            }\r",
-                  "        }\r",
-                  "\r",
-                  "        let schemaPropertyExceptions = [];\r",
-                  "        if (pm.environment.has('env-schemaPropertyExceptions')) {\r",
-                  "            schemaPropertyExceptions = JSON.parse(pm.environment.get('env-schemaPropertyExceptions'));\r",
-                  "        }\r",
-                  "\r",
-                  "        for (let prop in object.properties) {\r",
-                  "            const property = object.properties[prop];\r",
-                  "\r",
-                  "            if (!schemaPropertyExceptions.some(pe => pe === prop)) {\r",
-                  "                pm.test(`Schema property '${objectName}.${prop}' is lowercase`, function () {\r",
-                  "                    pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toLowerCase());\r",
-                  "                });\r",
-                  "            }\r",
-                  "\r",
-                  "            if (property.type && property.type.toLowerCase() == 'object') {\r",
-                  "                testSchemaObject(schema, property, `${objectName}.${prop}`);\r",
-                  "            }\r",
-                  "            else if (property.type && property.type.toLowerCase() == 'array') {\r",
-                  "                testSchemaObject(schema, property, `${objectName}.${prop}(list)`);\r",
-                  "            }\r",
-                  "            else if (property.oneOf) {\r",
-                  "                _.forEach(property.oneOf, (oneOf, i) => {\r",
-                  "                    testSchemaObject(schema, oneOf, `${objectName}.${prop}(oneOf).${i}`)\r",
-                  "                });\r",
-                  "            }\r",
-                  "            else if (property.allOf) {\r",
-                  "                _.forEach(property.allOf, (allOf, i) => {\r",
-                  "                    testSchemaObject(schema, allOf, `${objectName}.${prop}(allOf).${i}`)\r",
-                  "                });\r",
-                  "            }\r",
-                  "            else if (property.anyOf) {\r",
-                  "                _.forEach(property.anyOf, (anyOf, i) => {\r",
-                  "                    testSchemaObject(schema, anyOf, `${objectName}.${prop}(anyOf).${i}`)\r",
-                  "                });\r",
-                  "            }\r",
-                  "            else {\r",
-                  "                if (requireParamDescription && !property.$ref) {\r",
-                  "                    pm.test(`Schema property '${objectName}.${prop}' has a description between ${paramDescriptionMinLength} and ${paramDescriptionMaxLength} characters`, function () {\r",
-                  "                        pm.expect(property).to.have.property('description').and.to.be.a('string');\r",
-                  "                        pm.expect(property.description.length).to.be.at.least(paramDescriptionMinLength);\r",
-                  "                        pm.expect(property.description.length).to.be.at.most(paramDescriptionMaxLength);\r",
-                  "                    });\r",
-                  "\r",
-                  "                    if (property.description) {\r",
-                  "                        pm.test(`Schema property '${objectName}.${prop}' description is not just the name`, function () {\r",
-                  "                            pm.expect(prop.toLowerCase()).to.not.equal(property.description.toLowerCase());\r",
-                  "                        });\r",
-                  "                    }\r",
-                  "                }\r",
-                  "\r",
-                  "                if (requireParamExample && !property.$ref) {\r",
-                  "                    pm.test(`Schema property '${objectName}.${prop}' has an example`, function () {\r",
-                  "                        pm.expect(property).to.have.property('example');\r",
-                  "                    });\r",
-                  "                }\r",
-                  "            }\r",
-                  "        }\r",
-                  "    }\r",
-                  "    else if (object.type && object.type.toLowerCase() == 'array') {\r",
-                  "        pm.test(`Schema '${objectName}' has items defined`, function () {\r",
-                  "            pm.expect(object).to.have.property('items');\r",
-                  "        });\r",
-                  "\r",
-                  "        testSchemaObject(schema, object.items, `${objectName}.list`);\r",
-                  "    }\r",
-                  "    else if (object.oneOf) {\r",
-                  "        handleSchemaArray(schema, object, objectName, 'oneOf');\r",
-                  "    } else if (object.allOf) {\r",
-                  "        handleSchemaArray(schema, object, objectName, 'allOf');\r",
-                  "    }\r",
-                  "    else if (object.anyOf) {\r",
-                  "        handleSchemaArray(schema, object, objectName, 'anyOf');\r",
-                  "    }\r",
-                  "    else if (object.$ref) {\r",
-                  "        const name = getName(object.$ref);\r",
-                  "        const testedRef = testedSchemaRefs.find(tsr => tsr == name);\r",
-                  "        if (!testedRef) {\r",
-                  "            testSchemaObject(schema, schema.components.schemas[name], objectName);\r",
-                  "            testedSchemaRefs.push(name);\r",
-                  "        }\r",
-                  "    }\r",
-                  "    else {\r",
-                  "        pm.test(`Schema '${objectName}' has a declared type`, function () {\r",
-                  "            pm.expect(object).to.have.property('type');\r",
-                  "        });\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "function handleSchemaArray(schema, object, objectName, arrayType) {\r",
-                  "    for (let i = 0; i < object[arrayType].length; i++) {\r",
-                  "        const arraySchema = object[arrayType][i];\r",
-                  "        if (arraySchema.$ref) {\r",
-                  "            const name = getName(arraySchema.$ref);\r",
-                  "            const testedRef = testedSchemaRefs.find(tsr => tsr == name);\r",
-                  "            if (!testedRef) {\r",
-                  "                testSchemaObject(schema, schema.components.schemas[name], `${objectName}[${i}](ref ${name})`);\r",
-                  "                testedSchemaRefs.push(name);\r",
-                  "            }\r",
-                  "        }\r",
-                  "        else {\r",
-                  "            testSchemaObject(schema, arraySchema, `${objectName}[${i}]`);\r",
-                  "        }\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "function getName(ref) {\r",
-                  "    let pieces = ref.split('/');\r",
-                  "    return pieces[pieces.length - 1];\r",
-                  "}\r",
-                  ""
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "https://postman-echo.com/delay/0",
-              "protocol": "https",
-              "host": [
-                "postman-echo",
-                "com"
-              ],
-              "path": [
-                "delay",
-                "0"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Contract Tests",
-      "item": [
-        {
-          "name": "Build Schema Tests",
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  "const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
-                  "\r",
-                  "let schemaTests = [];    \r",
-                  "for(let prop in schema.paths){\r",
-                  "    const pathName = prop;    \r",
-                  "    let path = {\r",
-                  "        path: `${pm.collectionVariables.get('coll-baseUrl')}${pathName}`,\r",
-                  "        parameters: schema.paths[prop].parameters,        \r",
-                  "    };\r",
-                  "\r",
-                  "    for(let method in schema.paths[prop]){\r",
-                  "        if(method.toLowerCase() == 'parameters' || isMockEndpoint(schema.paths[prop][method])){\r",
-                  "            continue;\r",
-                  "        }       \r",
-                  "\r",
-                  "        let currentPath = _.cloneDeep(path);\r",
-                  "        currentPath.method = method.toUpperCase(); \r",
-                  "        let pathMethod = schema.paths[prop][method];\r",
-                  "        let securityExtension = pm.environment.get('env-securityExtensionName');        \r",
-                  "        if(securityExtension && pathMethod[securityExtension] && pathMethod[securityExtension].length > 0){\r",
-                  "            currentPath.allowedRole = pathMethod[securityExtension][0];\r",
-                  "        }\r",
-                  "\r",
-                  "        if(pathMethod.parameters && pathMethod.parameters.length > 0) {\r",
-                  "            if(currentPath.parameters) {\r",
-                  "                currentPath.parameters = pathMethod.parameters.concat(pathMethod.parameters,currentPath.parameters);\r",
-                  "            } else {\r",
-                  "                currentPath.parameters = pathMethod.parameters;\r",
-                  "            }\r",
-                  "        }\r",
-                  "\r",
-                  "        const expectedResponses = getExpectedResponses(pathMethod);\r",
-                  "        currentPath.responses = expectedResponses;\r",
-                  "\r",
-                  "        if(pathMethod.requestBody){\r",
-                  "            let bodyModel;\r",
-                  "            if(pathMethod.requestBody.content['application/json']) {\r",
-                  "                if(pathMethod.requestBody.content['application/json'].schema && pathMethod.requestBody.content['application/json'].schema.$ref){\r",
-                  "                    bodyModel = getSchemaReference(schema, pathMethod.requestBody.content['application/json'].schema.$ref);\r",
-                  "                } else {\r",
-                  "                    bodyModel = pathMethod.requestBody.content['application/json'].schema;\r",
-                  "                }\r",
-                  "            } else {\r",
-                  "                continue;\r",
-                  "            }\r",
-                  "            \r",
-                  "            const models = buildModels(schema, bodyModel);\r",
-                  "            const mutations = buildModelMutations(models);\r",
-                  "\r",
-                  "            mutations.forEach((mutation) => {\r",
-                  "                let schemaTest = _.cloneDeep(currentPath);\r",
-                  "                Object.assign(schemaTest, mutation);\r",
-                  "                schemaTest.name = `${schemaTest.method} - ${pathName} - ${schemaTest.description} - SUCCESS: ${schemaTest.success}`;\r",
-                  "                schemaTests.push(schemaTest);\r",
-                  "            });\r",
-                  "        }        \r",
-                  "        else {\r",
-                  "            currentPath.name = `${currentPath.method} - ${pathName} - No Request Body - SUCCESS: true`;\r",
-                  "            currentPath.success = true;\r",
-                  "            schemaTests.push(currentPath);\r",
-                  "        }\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "pm.collectionVariables.set('coll-schemaTests', JSON.stringify(schemaTests));\r",
-                  "\r",
-                  "//\r",
-                  "// Supporting Methods Below\r",
-                  "//\r",
-                  "function buildModels(schema, object){\r",
-                  "  let models = [];\r",
-                  "\r",
-                  "  if(object['$ref']){\r",
-                  "    object = getSchemaReference(schema, object['$ref']);\r",
-                  "  }\r",
-                  "  \r",
-                  "  if(object.type && object.type.toLowerCase() == 'object'){\r",
-                  "    if(object.required && object.required.length > 0){ \r",
-                  "      models.push({});\r",
-                  "      _.forEach(object.required, function(param){\r",
-                  "        const property = object.properties[param];\r",
-                  "        \r",
-                  "        if(property.type && ['string', 'number', 'integer', 'boolean'].includes(property.type.toLowerCase())){\r",
-                  "          for(let modelIndex = 0; modelIndex < models.length; modelIndex++){\r",
-                  "            let model = models[modelIndex];\r",
-                  "            model[param] = property.example;\r",
-                  "          }\r",
-                  "        }\r",
-                  "        else {\r",
-                  "          const nestedObjects = buildModels(schema, property);          \r",
-                  "          models = addToModels(models, nestedObjects, param);\r",
-                  "        }                  \r",
-                  "      });\r",
-                  "    }\r",
-                  "  }\r",
-                  "  else if(object.type && object.type.toLowerCase() == 'array'){    \r",
-                  "    let items = buildModels(schema, object.items);\r",
-                  "    if(Array.isArray(items)){\r",
-                  "      for(let i = 0; i < items.length; i++){\r",
-                  "        models.push([items[i]]);\r",
-                  "      }      \r",
-                  "    }\r",
-                  "    else {\r",
-                  "      models.push([items]);\r",
-                  "    }\r",
-                  "  }\r",
-                  "  else if (object.oneOf){  \r",
-                  "    _.forEach(object.oneOf, function(component){\r",
-                  "        let items = buildModels(schema, component);        \r",
-                  "      models = models.concat(items);\r",
-                  "    });    \r",
-                  "  }\r",
-                  "  else if (object.allOf){\r",
-                  "    let pieces = [{}];\r",
-                  "    _.forEach(object.allOf, function(component){\r",
-                  "        let componentModels = buildModels(schema, component);\r",
-                  "        pieces = addToModels(pieces, componentModels);        \r",
-                  "    });\r",
-                  "    \r",
-                  "    models = pieces;\r",
-                  "  }\r",
-                  "  else if (object.anyOf){\r",
-                  "      let pieces = [];\r",
-                  "      let combinedPieces = [{}];\r",
-                  "      _.forEach(object.anyOf, function(component){\r",
-                  "        let componentModels = buildModels(schema, component);\r",
-                  "        combinedPieces = addToModels(combinedPieces, componentModels);\r",
-                  "        pieces = pieces.concat(componentModels);\r",
-                  "      });\r",
-                  "\r",
-                  "      models = pieces.concat(combinedPieces);\r",
-                  "  }\r",
-                  "  else {\r",
-                  "    // All other options are primitive values\r",
-                  "    return object.example;\r",
-                  "  }\r",
-                  "  return models;\r",
-                  "}\r",
-                  "\r",
-                  "function getSchemaReference(schema, referenceName){  \r",
-                  "  const refPieces = referenceName.split('/');\r",
-                  "  let reference = schema;\r",
-                  "  for(let i = 1; i < refPieces.length; i++){\r",
-                  "    reference = reference[refPieces[i]];\r",
-                  "  }\r",
-                  "\r",
-                  "  return reference;  \r",
-                  "}\r",
-                  "\r",
-                  "function addToModels(models, newPieces, name){\r",
-                  "  let newModels = [];\r",
-                  "  _.forEach(models, function(model){\r",
-                  "    _.forEach(newPieces, function(newPiece){\r",
-                  "      let newModel = _.cloneDeep(model);\r",
-                  "      if(name){\r",
-                  "        newModel[name] = newPiece;\r",
-                  "      }\r",
-                  "      else {\r",
-                  "        Object.assign(newModel, newPiece);\r",
-                  "      }\r",
-                  "      newModels.push(newModel);\r",
-                  "    });\r",
-                  "  });\r",
-                  "\r",
-                  "  return newModels;\r",
-                  "}\r",
-                  "\r",
-                  "function buildModelMutations(models){    \r",
-                  "  let modelMutations = [];\r",
-                  "  _.forEach(models, function(model){  \r",
-                  "    addMutation(true, 'Has all required fields', model, modelMutations);\r",
-                  "    let mutations = buildMutation(model);\r",
-                  "    modelMutations = modelMutations.concat(mutations);\r",
-                  "  });\r",
-                  "\r",
-                  "  return modelMutations;\r",
-                  "}\r",
-                  "\r",
-                  "function buildMutation(model){\r",
-                  "  let mutations = [];  \r",
-                  "\r",
-                  "  for(const [key, value] of Object.entries(model)){\r",
-                  "    if(typeof value == 'object'){          \r",
-                  "      let nestedMutations = buildMutation(value);\r",
-                  "      nestedMutations.forEach((nestedMutation) => {\r",
-                  "        let mutation = _.cloneDeep(model);\r",
-                  "        mutation[key] = nestedMutation.body;\r",
-                  "        addMutation(false, `${nestedMutation.description} in ${key} object`, mutation, mutations);\r",
-                  "      });\r",
-                  "      \r",
-                  "      let mutation = _.cloneDeep(model);\r",
-                  "      delete mutation[key];\r",
-                  "      addMutation(false, `Missing ${key} object`, mutation, mutations);\r",
-                  "\r",
-                  "      let emptyMutation = _.cloneDeep(model);\r",
-                  "      emptyMutation[key] = {};\r",
-                  "      addMutation(false, `Empty ${key} object`, emptyMutation, mutations);\r",
-                  "    }\r",
-                  "    else {\r",
-                  "      if(Array.isArray(value)){\r",
-                  "        console.log('probably an error');\r",
-                  "      }\r",
-                  "      let mutation = _.cloneDeep(model);\r",
-                  "      delete mutation[key];\r",
-                  "      addMutation(false, `Missing ${key} property`, mutation, mutations);\r",
-                  "\r",
-                  "      let blankMutation = _.cloneDeep(model);\r",
-                  "      blankMutation[key] = '';\r",
-                  "      addMutation(false, `Blank ${key} property`, blankMutation, mutations);\r",
-                  "    }\r",
-                  "  }\r",
-                  "\r",
-                  "  return mutations;\r",
-                  "}\r",
-                  "\r",
-                  "function addMutation(isSuccess, description, mutation, mutations){\r",
-                  "  mutations.push({\r",
-                  "    success: isSuccess, \r",
-                  "    description: description,\r",
-                  "    body: mutation\r",
-                  "  });\r",
-                  "}\r",
-                  "\r",
-                  "function getExpectedResponses(pathMethod){\r",
-                  "    const responses = [];\r",
-                  "        for(const [statusCode, value] of Object.entries(pathMethod.responses)){\r",
-                  "            let response = {\r",
-                  "                statusCode: Number(statusCode)\r",
-                  "            };\r",
-                  "\r",
-                  "            if(value['x-postman-variables'] && Array.isArray(value['x-postman-variables'])){\r",
-                  "                response.variables = value['x-postman-variables'].filter(variable => variable.type.toLowerCase() === 'save');\r",
-                  "            }\r",
-                  "\r",
-                  "            if(value.$ref){\r",
-                  "                response.$ref = value.$ref;                \r",
-                  "            }\r",
-                  "            else\r",
-                  "            {\r",
-                  "                if(value.content && value.content['application/json'] && value.content['application/json'].schema){\r",
-                  "                    if(value.content['application/json'].schema.$ref){\r",
-                  "                       response.$ref = value.content['application/json'].schema.$ref;                        \r",
-                  "                    }\r",
-                  "                    else {\r",
-                  "                       response.schema = value.content['application/json'].schema;\r",
-                  "                    }\r",
-                  "                }\r",
-                  "            }            \r",
-                  "\r",
-                  "            responses.push(response);\r",
-                  "        }\r",
-                  "    return responses;\r",
-                  "}\r",
-                  "\r",
-                  "function isMockEndpoint(pathMethod){\r",
-                  "    let isMock = false;\r",
-                  "    if(pathMethod && pathMethod['x-amazon-apigateway-integration'] && pathMethod['x-amazon-apigateway-integration'].type \r",
-                  "        && pathMethod['x-amazon-apigateway-integration'].type.toLowerCase() == 'mock') {\r",
-                  "        isMock = true;\r",
-                  "    }\r",
-                  "\r",
-                  "    return isMock;\r",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "let schemaTests = pm.collectionVariables.get('coll-schemaTests');\r",
-                  "if(schemaTests){\r",
-                  "    schemaTests = JSON.parse(schemaTests);\r",
-                  "    if(!schemaTests || !schemaTests.length){\r",
-                  "        postman.setNextRequest('More APIs to Process?');\r",
-                  "    }\r",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "https://postman-echo.com/delay/0",
-              "protocol": "https",
-              "host": [
-                "postman-echo",
-                "com"
-              ],
-              "path": [
-                "delay",
-                "0"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Test Request",
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  "const url = require('url');\r",
-                  "\r",
-                  "const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
-                  "let schemaTests = JSON.parse(pm.collectionVariables.get('coll-schemaTests'));\r",
-                  "\r",
-                  "const schemaTest = schemaTests.shift();\r",
-                  "pm.collectionVariables.set('coll-schemaTests', JSON.stringify(schemaTests));\r",
-                  "pm.variables.set('currentSchemaTest', JSON.stringify(schemaTest));\r",
-                  "\r",
-                  "const path = replacePathParameters(schema, schemaTest.path, schemaTest.parameters);\r",
-                  "pm.request.url.update(path);\r",
-                  "delete pm.request.url.auth;\r",
-                  "delete pm.request.url.port;\r",
-                  "delete pm.request.url.hash;\r",
-                  "pm.request.url.protocol = pm.request.url.protocol.replace(/\\:$/, '');\r",
-                  "pm.request.method = schemaTest.method;\r",
-                  "pm.request.name = schemaTest.name;\r",
-                  "\r",
-                  "pm.variables.set('requestName', schemaTest.name);\r",
-                  "pm.variables.set('body', JSON.stringify(schemaTest.body));\r",
-                  "\r",
-                  "// Add top level parameters from the path\r",
-                  "const roleHeaderName = pm.environment.get('env-roleHeaderName');\r",
-                  "\r",
-                  "if(schemaTest.parameters){\r",
-                  "    for(let i = 0; i < schemaTest.parameters.length; i++){\r",
-                  "        let param = schemaTest.parameters[i];\r",
-                  "\r",
-                  "        if (param.$ref) {\r",
-                  "            let pieces = param.$ref.split('/');\r",
-                  "            const name = pieces[pieces.length-1];\r",
-                  "            const schemaParam = schema.components.parameters[name];\r",
-                  "            const paramType = schemaParam.in.toLowerCase();\r",
-                  "            const paramValue = loadParameterValue(schemaParam);\r",
-                  "            if(paramType == 'header'){\r",
-                  "                if(roleHeaderName && schemaParam.name.toLowerCase() == roleHeaderName.toLowerCase()){\r",
-                  "                    pm.request.headers.upsert({ key: schemaParam.name, value: schemaTest.allowedRole });    \r",
-                  "                } \r",
-                  "                else {\r",
-                  "                    pm.request.headers.upsert({ key: schemaParam.name, value: paramValue });\r",
-                  "                }\r",
-                  "            } else if (paramType == 'query' && schemaParam.required == true) {\r",
-                  "                pm.request.url.query.upsert({ key: schemaParam.name, value: paramValue });\r",
-                  "            }\r",
-                  "        } else {\r",
-                  "            const paramType = param.in.toLowerCase();\r",
-                  "            const paramValue = loadParameterValue(param);\r",
-                  "            if (paramType == 'header') {\r",
-                  "                pm.request.headers.upsert({ key: param.name, value: paramValue });\r",
-                  "            } else if (paramType == 'query' && param.required == true) {\r",
-                  "                pm.request.url.query.upsert({ key: param.name, value: paramValue });\r",
-                  "            }\r",
-                  "        }\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "function loadParameterValue(parameter){\r",
-                  "    let parameterValue;\r",
-                  "    if(parameter['x-postman-variables']){\r",
-                  "        let variable = parameter['x-postman-variables'].find(v => v.type.toLowerCase() === 'load');\r",
-                  "        if(variable && pm.collectionVariables.has(variable.name)){\r",
-                  "            parameterValue = pm.collectionVariables.get(variable.name);\r",
-                  "        }\r",
-                  "        else {\r",
-                  "            parameterValue = encodeURIComponent(parameter.schema.example ? parameter.schema.example : parameter.example);    \r",
-                  "        }\r",
-                  "    }\r",
-                  "    else {\r",
-                  "        parameterValue = encodeURIComponent(parameter.schema.example ? parameter.schema.example : parameter.example);\r",
-                  "    }\r",
-                  "\r",
-                  "    return parameterValue;\r",
-                  "}\r",
-                  "\r",
-                  "function replacePathParameters(schema, pathName, parameters){\r",
-                  "    let replacedPathName = pathName;\r",
-                  "    let pathVariableRegex = /{([^}]*)}/g;\r",
-                  "    let matches = pathName.match(pathVariableRegex);\r",
-                  "    _.forEach(matches, function(match){\r",
-                  "        let paramName = match.substring(1, match.length - 1);\r",
-                  "        _.forEach(parameters, function(param){\r",
-                  "            if(param.$ref){\r",
-                  "                let parameter = getSchemaReference(schema, param.$ref);                \r",
-                  "                if (parameter.in && parameter.in.toLowerCase() == 'path' && parameter.name && parameter.name == paramName){\r",
-                  "                    let parameterValue = loadParameterValue(parameter);\r",
-                  "                    replacedPathName = replacedPathName.replace(match, parameterValue);\r",
-                  "                    return false;\r",
-                  "                }\r",
-                  "            } else {\r",
-                  "                if (param.in && param.in.toLowerCase() == 'path' && param.name && param.name == paramName) {\r",
-                  "                    let parameterValue = loadParameterValue(param);\r",
-                  "                    replacedPathName = replacedPathName.replace(match, parameterValue);\r",
-                  "                    return false;\r",
-                  "                }\r",
-                  "            }\r",
-                  "        });    \r",
-                  "    });\r",
-                  "\r",
-                  "    return url.parse(replacedPathName);\r",
-                  "}\r",
-                  "\r",
-                  "function getSchemaReference(schema, referenceName){  \r",
-                  "  const refPieces = referenceName.split('/');\r",
-                  "  let reference = schema;\r",
-                  "  for(let i = 1; i < refPieces.length; i++){\r",
-                  "    reference = reference[refPieces[i]];\r",
-                  "  }\r",
-                  "\r",
-                  "  return reference;  \r",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "const schemaTests = JSON.parse(pm.collectionVariables.get('coll-schemaTests'));\r",
-                  "if(schemaTests.length > 0){\r",
-                  "    postman.setNextRequest('Test Request');\r",
-                  "}\r",
-                  "\r",
-                  "const schemaTest = JSON.parse(pm.variables.get('currentSchemaTest'));\r",
-                  "\r",
-                  "pm.test(`${schemaTest.name} - Has expected status code`, function () {\r",
-                  "    if(schemaTest.success){\r",
-                  "        pm.expect(pm.response.code).to.not.equal(400);\r",
-                  "    }\r",
-                  "    else {\r",
-                  "        pm.response.to.have.status(400);\r",
-                  "    }    \r",
-                  "});\r",
-                  "\r",
-                  "\r",
-                  "const expectedResponse = schemaTest.responses.find(r => r.statusCode == pm.response.code);\r",
-                  "pm.test(`${schemaTest.name} - Status code is allowed`, function(){\r",
-                  "    pm.expect(expectedResponse).to.exist;\r",
-                  "});\r",
-                  "\r",
-                  "if(expectedResponse){\r",
-                  "    pm.test(`${schemaTest.name} - Has expected response body schema`, function(){\r",
-                  "        const Ajv = require('ajv');\r",
-                  "        const ajv = new Ajv({allErrors: true,format: false});\r",
-                  "        \r",
-                  "        if(pm.response.code == 204 || shouldResponseBeEmpty(expectedResponse)){\r",
-                  "            checkForEmptyResponse();\r",
-                  "        }\r",
-                  "        else if(expectedResponse.$ref){            \r",
-                  "            const jsonData = pm.response.json();\r",
-                  "            const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
-                  "            ajv.addSchema(schema, 'OAS');\r",
-                  "            \r",
-                  "            const valid = ajv.validate({$ref: `OAS${expectedResponse.$ref}`}, jsonData);\r",
-                  "            const errors = ajv.errorsText(valid.errors);\r",
-                  "            pm.expect(errors).to.equal('No errors');\r",
-                  "            if(errors !== 'No errors'){\r",
-                  "                console.log(errors);\r",
-                  "            }\r",
-                  "        }\r",
-                  "        else if(expectedResponse.schema){\r",
-                  "            const jsonData = pm.response.json();\r",
-                  "            const validate = ajv.compile(expectedResponse.schema);\r",
-                  "            const valid = validate(jsonData);\r",
-                  "            const errors = ajv.errorsText(valid.errors);\r",
-                  "            pm.expect(errors).to.equal('No errors');\r",
-                  "            if(errors !== 'No errors'){\r",
-                  "                console.log(errors);\r",
-                  "            }\r",
-                  "        }\r",
-                  "        else {\r",
-                  "            checkForEmptyResponse();\r",
-                  "        }\r",
-                  "\r",
-                  "        if(expectedResponse.variables){\r",
-                  "            const jsonData = pm.response.json();\r",
-                  "            _.forEach(expectedResponse.variables, function(variable){\r",
-                  "                let pathPieces = variable.path.split('.').filter(piece => piece);\r",
-                  "                let data = jsonData;\r",
-                  "                let found = true;\r",
-                  "                _.forEach(pathPieces, function(piece){\r",
-                  "                    if(data[piece]){\r",
-                  "                        data = data[piece];\r",
-                  "                    }\r",
-                  "                    else {\r",
-                  "                        found = false;\r",
-                  "                    }\r",
-                  "                });\r",
-                  "\r",
-                  "                if(found){\r",
-                  "                    pm.collectionVariables.set(variable.name, data);\r",
-                  "                }\r",
-                  "                else {\r",
-                  "                    pm.test(`Unable to save dynamic variable ${variable.name} at the provided path.`, function() {\r",
-                  "                        pm.expect(true).to.equal(variable.path);\r",
-                  "                    });\r",
-                  "                }\r",
-                  "            });\r",
-                  "        }\r",
-                  "    });\r",
-                  "}\r",
-                  "\r",
-                  "function checkForEmptyResponse() {\r",
-                  "    let emptyBody = true;\r",
-                  "    if(pm.response.text()){\r",
-                  "        emptyBody = false; \r",
-                  "    }\r",
-                  "\r",
-                  "    pm.expect(emptyBody).to.be.true;\r",
-                  "}\r",
-                  "\r",
-                  "function shouldResponseBeEmpty(expectedResponse){\r",
-                  "    let responseSchema = expectedResponse.schema;\r",
-                  "    if(expectedResponse.$ref){\r",
-                  "        let schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
-                  "        responseSchema = getSchemaReference(schema, expectedResponse.$ref);\r",
-                  "        if(expectedResponse.$ref.startsWith('#/components/responses')){\r",
-                  "            return (!responseSchema || !responseSchema.content || !responseSchema.content['application/json'] \r",
-                  "                || !responseSchema.content['application/json'].schema || Object.keys(responseSchema.content['application/json'].schema).length == 0);\r",
-                  "        } else {\r",
-                  "            return false;\r",
-                  "        }\r",
-                  "    }\r",
-                  "    else {\r",
-                  "        return (responseSchema === undefined || Object.keys(responseSchema).length == 0);\r",
-                  "    }\r",
-                  "}\r",
-                  "\r",
-                  "function getSchemaReference(schema, referenceName){  \r",
-                  "  const refPieces = referenceName.split('/');\r",
-                  "  let reference = schema;\r",
-                  "  for(let i = 1; i < refPieces.length; i++){\r",
-                  "    reference = reference[refPieces[i]];\r",
-                  "  }\r",
-                  "\r",
-                  "  return reference;  \r",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "protocolProfileBehavior": {
-            "disableBodyPruning": true
-          },
-          "request": {
-            "method": "GET",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{{body}}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "https://postman-echo.com/get",
-              "protocol": "https",
-              "host": [
-                "postman-echo",
-                "com"
-              ],
-              "path": [
-                "get"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Finalize",
-      "item": [
-        {
-          "name": "More APIs to Process?",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "let apis = pm.collectionVariables.get('coll-apiIds');\r",
-                  "if(apis){\r",
-                  "    try{\r",
-                  "        apis = JSON.parse(apis);\r",
-                  "        if(apis.length > 0){\r",
-                  "            postman.setNextRequest('Get Current API Version');\r",
-                  "        }\r",
-                  "    }\r",
-                  "    catch(err){}    \r",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "noauth"
-            },
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "https://postman-echo.com/delay/0",
-              "protocol": "https",
-              "host": [
-                "postman-echo",
-                "com"
-              ],
-              "path": [
-                "delay",
-                "0"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Remove Test Variables",
-          "event": [
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  "// See https://blog.postman.com/2019/05/28/pro-tip-dynamically-unset-postman-environment-variables/\r",
-                  "// for more details on what we're doing here. \r",
-                  "\r",
-                  "cleanupCollectionVariables();\r",
-                  "\r",
-                  "function cleanupCollectionVariables() {\r",
-                  "    const clean = _.keys(pm.collectionVariables.toObject());\r",
-                  "\r",
-                  "    _.each(clean, (arrItem) => {\r",
-                  "        pm.collectionVariables.unset(arrItem);\r",
-                  "    });\r",
-                  "}"
-                ],
-                "type": "text/javascript"
-              }
-            },
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  ""
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "https://postman-echo.com/delay/0",
-              "protocol": "https",
-              "host": [
-                "postman-echo",
-                "com"
-              ],
-              "path": [
-                "delay",
-                "0"
-              ]
-            }
-          },
-          "response": []
-        }
-      ]
-    }
-  ],
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          ""
-        ]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "exec": [
-          ""
-        ]
-      }
-    }
-  ]
+	"item": [
+		{
+			"name": "API Validation",
+			"item": [
+				{
+					"name": "Initialize",
+					"item": [
+						{
+							"name": "Cleanup Previous Run",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// See https://blog.postman.com/2019/05/28/pro-tip-dynamically-unset-postman-environment-variables/\r",
+											"// for more details on what we're doing here. \r",
+											"\r",
+											"cleanupCollectionVariables();\r",
+											"\r",
+											"function cleanupCollectionVariables() {\r",
+											"    const clean = _.keys(pm.collectionVariables.toObject());\r",
+											"\r",
+											"    _.each(clean, (arrItem) => {\r",
+											"        pm.collectionVariables.unset(arrItem);\r",
+											"    });\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://postman-echo.com/delay/0",
+									"protocol": "https",
+									"host": [
+										"postman-echo",
+										"com"
+									],
+									"path": [
+										"delay",
+										"0"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Initialize",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const providedSchema = pm.environment.get('env-schema');\r",
+											"if(providedSchema){\r",
+											"    let success = true;\r",
+											"    try{\r",
+											"        const yaml = pm.environment.get('env-jsonToYaml');\r",
+											"        (new Function(yaml))();\r",
+											"\r",
+											"        const schema = jsyaml.load(providedSchema);\r",
+											"        pm.collectionVariables.set('coll-schema', JSON.stringify(schema));\r",
+											"        postman.setNextRequest('Verify Component Adherence');\r",
+											"    }\r",
+											"    catch(err){\r",
+											"        console.log(err);\r",
+											"        success = false;\r",
+											"        postman.setNextRequest(null);\r",
+											"    }\r",
+											"\r",
+											"    pm.test('Successfully converted provided schema', function(){\r",
+											"        pm.expect(success).to.be.true;\r",
+											"    });    \r",
+											"} else {\r",
+											"    const schemaUrl = pm.environment.get('env-schemaUrl');\r",
+											"\r",
+											"    if (schemaUrl && schemaUrl != \"\") {\r",
+											"        postman.setNextRequest(\"Get Schema From URL\");\r",
+											"    } else {\r",
+											"        postman.setNextRequest(\"Validate API In Workspace\");\r",
+											"    }\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://postman-echo.com/delay/0",
+									"protocol": "https",
+									"host": [
+										"postman-echo",
+										"com"
+									],
+									"path": [
+										"delay",
+										"0"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get Schema from URL",
+					"item": [
+						{
+							"name": "Get Schema From URL",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let responseSchema = pm.response.text();",
+											"",
+											"if(responseSchema.length != 0) {",
+											"    let success = true;",
+											"    try{",
+											"        const yaml = pm.environment.get('env-jsonToYaml');",
+											"        (new Function(yaml))();",
+											"",
+											"        const schema = jsyaml.load(responseSchema);",
+											"        pm.collectionVariables.set('coll-schema', JSON.stringify(schema));",
+											"        postman.setNextRequest('Get API Base Url');",
+											"    }",
+											"    catch(err){",
+											"        console.log(err);",
+											"        success = false;",
+											"        postman.setNextRequest(null);",
+											"    }",
+											"",
+											"    pm.test('Successfully converted provided schema', function(){",
+											"        pm.expect(success).to.be.true;",
+											"    }); ",
+											"} else {",
+											"    console.log(\"Error retrieving schema from URL - \" + pm.environment.get(\"env-schemaUrl\"));",
+											"    postman.setNextRequest(null);",
+											"}",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{env-schemaUrl}}",
+									"host": [
+										"{{env-schemaUrl}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get Schema from Postman",
+					"item": [
+						{
+							"name": "Validate API In Workspace",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const minApiCount = Number(pm.environment.get('env-minApiCount'));\r",
+											"const maxApiCount = Number(pm.environment.get('env-maxApiCount'));\r",
+											"const jsonData = pm.response.json();\r",
+											"\r",
+											"pm.test(`Workspace API count is between ${minApiCount} and ${maxApiCount}. (Count: ${jsonData.apis.length})`, function () {    \r",
+											"    pm.expect(jsonData.apis.length).to.be.at.least(minApiCount);    \r",
+											"    pm.expect(jsonData.apis.length).to.be.at.most(maxApiCount);\r",
+											"});\r",
+											"\r",
+											"let apiIds = [];\r",
+											"_.forEach(jsonData.apis, function(api){\r",
+											"    apiIds.push(api.id);\r",
+											"});\r",
+											"\r",
+											"pm.collectionVariables.set('coll-apiIds', JSON.stringify(apiIds));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Api-Key",
+										"value": "{{env-apiKey}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "https://api.getpostman.com/apis?workspace={{env-workspaceId}}",
+									"protocol": "https",
+									"host": [
+										"api",
+										"getpostman",
+										"com"
+									],
+									"path": [
+										"apis"
+									],
+									"query": [
+										{
+											"key": "workspace",
+											"value": "{{env-workspaceId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Current API Version",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json();\r",
+											"\r",
+											"pm.test('API has one or more versions', function(){\r",
+											"    pm.expect(jsonData).to.have.property('versions').and.to.be.an('array');\r",
+											"    pm.expect(jsonData.versions.length).to.be.above(0);\r",
+											"});\r",
+											"\r",
+											"const version = jsonData.versions[0];\r",
+											"pm.collectionVariables.set('coll-versionId', version.id);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"let apiIds = pm.collectionVariables.get('coll-apiIds');\r",
+											"if(apiIds){\r",
+											"    apiIds = JSON.parse(apiIds);\r",
+											"    const apiId = apiIds.pop();\r",
+											"\r",
+											"    pm.collectionVariables.set('coll-apiId', apiId);\r",
+											"    pm.collectionVariables.set('coll-apiIds', JSON.stringify(apiIds));\r",
+											"}\r",
+											"else {\r",
+											"    pm.request.url = 'https://postman-echo.com/delay/0'\r",
+											"    pm.request.name = 'No APIs found in the workspace. Skipping execution';\r",
+											"    postman.setNextRequest(null);\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Api-Key",
+										"value": "{{env-apiKey}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "https://api.getpostman.com/apis/:apiId/versions",
+									"protocol": "https",
+									"host": [
+										"api",
+										"getpostman",
+										"com"
+									],
+									"path": [
+										"apis",
+										":apiId",
+										"versions"
+									],
+									"query": [
+										{
+											"key": null,
+											"value": "",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "apiId",
+											"value": "{{coll-apiId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get Current API Schema",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const jsonData = pm.response.json();\r",
+											"\r",
+											"pm.test('Has schema for current version', function(){\r",
+											"    pm.expect(jsonData).to.have.property('version');\r",
+											"    pm.expect(jsonData.version).to.have.property('schema').and.to.be.an('array');\r",
+											"    pm.expect(jsonData.version.schema.length).to.be.above(0);\r",
+											"\r",
+											"    pm.collectionVariables.set('coll-schemaId', jsonData.version.schema[0]);\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Api-Key",
+										"type": "text",
+										"value": "{{env-apiKey}}"
+									}
+								],
+								"url": {
+									"raw": "https://api.getpostman.com/apis/:apiId/versions/:versionId",
+									"protocol": "https",
+									"host": [
+										"api",
+										"getpostman",
+										"com"
+									],
+									"path": [
+										"apis",
+										":apiId",
+										"versions",
+										":versionId"
+									],
+									"query": [
+										{
+											"key": null,
+											"value": "",
+											"disabled": true
+										}
+									],
+									"variable": [
+										{
+											"key": "apiId",
+											"value": "{{coll-apiId}}"
+										},
+										{
+											"key": "versionId",
+											"value": "{{coll-versionId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get API Schema",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"try {\r",
+											"    const jsonData = pm.response.json();\r",
+											"\r",
+											"    if(jsonData.schema.language.toLowerCase() == 'json'){\r",
+											"        pm.test('Schema is JSON', function(){\r",
+											"            pm.expect(1).to.equal(1);\r",
+											"            pm.collectionVariables.set('coll-schema', jsonData.schema.schema);\r",
+											"        });\r",
+											"    }\r",
+											"    else {\r",
+											"        pm.test('Schema translates to JSON', function(){\r",
+											"            try{\r",
+											"                const yaml = pm.environment.get('env-jsonToYaml');\r",
+											"                (new Function(yaml))();\r",
+											"\r",
+											"                const schema = jsyaml.load(jsonData.schema.schema);\r",
+											"                pm.collectionVariables.set('coll-schema', JSON.stringify(schema));\r",
+											"                pm.expect(1).to.equal(1);\r",
+											"            }\r",
+											"            catch(err){\r",
+											"                pm.expect(`${err.name} - ${err.message}`).to.equal(undefined);\r",
+											"            }    \r",
+											"        });\r",
+											"    }\r",
+											"}\r",
+											"catch(err) {\r",
+											"    console.log(err);\r",
+											"    pm.test('Unable to load schema', function(){\r",
+											"        pm.expect(0).to.equal(1);\r",
+											"        postman.setNextRequest(null);\r",
+											"    })\r",
+											"}"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-Api-Key",
+										"value": "{{env-apiKey}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "https://api.getpostman.com/apis/:apiId/versions/:apiVersionId/schemas/:schemaId",
+									"protocol": "https",
+									"host": [
+										"api",
+										"getpostman",
+										"com"
+									],
+									"path": [
+										"apis",
+										":apiId",
+										"versions",
+										":apiVersionId",
+										"schemas",
+										":schemaId"
+									],
+									"variable": [
+										{
+											"key": "apiId",
+											"value": "{{coll-apiId}}"
+										},
+										{
+											"key": "apiVersionId",
+											"value": "{{coll-versionId}}"
+										},
+										{
+											"key": "schemaId",
+											"value": "{{coll-schemaId}}"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get API Base Url",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
+									"const server = pm.environment.get('env-server');\r",
+									"\r",
+									"pm.test('Environment has test server defined', function () {\r",
+									"    pm.expect(server).to.not.be.undefined;\r",
+									"});\r",
+									"\r",
+									"pm.test('Schema has server/baseUrl defined', function () {\r",
+									"    const servers = schema.servers;\r",
+									"    pm.expect(servers).to.not.be.undefined;\r",
+									"    const serverToTest = servers.find(s => s.url.toLowerCase() == server.toLowerCase());\r",
+									"    pm.expect(serverToTest).to.not.be.undefined;\r",
+									"\r",
+									"    pm.expect(serverToTest).to.have.property('url');\r",
+									"    pm.collectionVariables.set('coll-baseUrl', serverToTest.url);\r",
+									"});\r",
+									"\r",
+									"const runComponentTests = pm.environment.get('env-runComponentTests') == 'true';\r",
+									"if(!runComponentTests){   \r",
+									"    const runContractTests = pm.environment.get('env-runContractTests') == 'true';\r",
+									"    if(runContractTests){\r",
+									"        postman.setNextRequest('Build Schema Tests');\r",
+									"    } else {\r",
+									"        postman.setNextRequest('More APIs to Process?');\r",
+									"    }   \r",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://postman-echo.com/delay/0",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"delay",
+								"0"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Components",
+			"item": [
+				{
+					"name": "Verify Component Adherence",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
+									"\r",
+									"const requireParamDescription = Boolean(pm.environment.get('env-requireParamDescription'));\r",
+									"const requireParamExample = Boolean(pm.environment.get('env-requireParamExample'));\r",
+									"\r",
+									"let paramDescriptionMinLength = pm.environment.get('env-paramDescriptionMinLength');\r",
+									"if (paramDescriptionMinLength) {\r",
+									"    paramDescriptionMinLength = Number(paramDescriptionMinLength);\r",
+									"}\r",
+									"\r",
+									"let paramDescriptionMaxLength = pm.environment.get('env-paramDesciptionMaxLength');\r",
+									"if (paramDescriptionMaxLength) {\r",
+									"    paramDescriptionMaxLength = Number(paramDescriptionMaxLength);\r",
+									"}\r",
+									"\r",
+									"var testedSchemaRefs = [];\r",
+									"\r",
+									"if (schema.components.parameters) {\r",
+									"    for (let prop in schema.components.parameters) {\r",
+									"        let parameter = schema.components.parameters[prop];\r",
+									"\r",
+									"        pm.test(`Parameter '${prop}' starts with a lowercase letter`, function () {\r",
+									"            pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toLowerCase());\r",
+									"        });\r",
+									"\r",
+									"        if (requireParamDescription) {\r",
+									"            pm.test(`Parameter '${prop}' has a description between ${paramDescriptionMinLength} and ${paramDescriptionMaxLength} characters`, function () {\r",
+									"                pm.expect(parameter).to.have.property('description').and.to.be.a('string');\r",
+									"                pm.expect(parameter.description.length).to.be.at.least(paramDescriptionMinLength);\r",
+									"                pm.expect(parameter.description.length).to.be.at.most(paramDescriptionMaxLength);\r",
+									"            });\r",
+									"        }\r",
+									"\r",
+									"        if (requireParamExample) {\r",
+									"            pm.test(`Parameter '${prop}' has an example`, function () {\r",
+									"                pm.expect(parameter).to.have.property('schema');\r",
+									"                pm.expect(parameter.schema).to.have.property('example');\r",
+									"            });\r",
+									"        }\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"if (schema.components.schemas) {\r",
+									"    for (let prop in schema.components.schemas) {\r",
+									"        pm.test(`Schema '${prop}' begins with an uppercase letter`, function () {\r",
+									"            pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toUpperCase());\r",
+									"        });\r",
+									"\r",
+									"        const testedSchema = testedSchemaRefs.find(tsr => tsr == prop);\r",
+									"        if (!testedSchema) {\r",
+									"            const schemaObject = schema.components.schemas[prop];\r",
+									"            testSchemaObject(schema, schemaObject, prop);\r",
+									"            testedSchemaRefs.push(prop);\r",
+									"        }\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"if (schema.components.responses) {\r",
+									"    for (let prop in schema.components.responses) {\r",
+									"        pm.test(`Response '${prop}' begins with an uppercase letter`, function () {\r",
+									"            pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toUpperCase());\r",
+									"        });\r",
+									"\r",
+									"        if (requireParamDescription) {\r",
+									"            const response = schema.components.responses[prop];\r",
+									"            pm.test(`Response '${prop}' has a description between ${paramDescriptionMinLength} and ${paramDescriptionMaxLength} characters`, function () {\r",
+									"                pm.expect(response).to.have.property('description').and.to.be.a('string');\r",
+									"                pm.expect(response.description.length).to.be.at.least(paramDescriptionMinLength);\r",
+									"                pm.expect(response.description.length).to.be.at.most(paramDescriptionMaxLength);\r",
+									"            });\r",
+									"        }\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"const runContractTests = pm.environment.get('env-runContractTests') == 'true';\r",
+									"if (runContractTests) {\r",
+									"    postman.setNextRequest('Build Schema Tests');\r",
+									"} else {\r",
+									"    postman.setNextRequest('More APIs to Process?');\r",
+									"}\r",
+									"\r",
+									"\r",
+									"function testSchemaObject(schema, object, objectName) {\r",
+									"    if (object.type && object.type.toLowerCase() == 'object') {\r",
+									"        if (object.required) {\r",
+									"            for (let i = 0; i < object.required.length; i++) {\r",
+									"                const requiredProp = object.required[i];\r",
+									"                pm.test(`Schema '${objectName}' has required property '${requiredProp}' defined`, function () {\r",
+									"                    pm.expect(object.properties).to.have.property(requiredProp);\r",
+									"                });\r",
+									"            }\r",
+									"        }\r",
+									"\r",
+									"        let schemaPropertyExceptions = [];\r",
+									"        if (pm.environment.has('env-schemaPropertyExceptions')) {\r",
+									"            schemaPropertyExceptions = JSON.parse(pm.environment.get('env-schemaPropertyExceptions'));\r",
+									"        }\r",
+									"\r",
+									"        for (let prop in object.properties) {\r",
+									"            const property = object.properties[prop];\r",
+									"\r",
+									"            if (!schemaPropertyExceptions.some(pe => pe === prop)) {\r",
+									"                pm.test(`Schema property '${objectName}.${prop}' is lowercase`, function () {\r",
+									"                    pm.expect(prop.charAt(0)).to.equal(prop.charAt(0).toLowerCase());\r",
+									"                });\r",
+									"            }\r",
+									"\r",
+									"            if (property.type && property.type.toLowerCase() == 'object') {\r",
+									"                testSchemaObject(schema, property, `${objectName}.${prop}`);\r",
+									"            }\r",
+									"            else if (property.type && property.type.toLowerCase() == 'array') {\r",
+									"                testSchemaObject(schema, property, `${objectName}.${prop}(list)`);\r",
+									"            }\r",
+									"            else if (property.oneOf) {\r",
+									"                _.forEach(property.oneOf, (oneOf, i) => {\r",
+									"                    testSchemaObject(schema, oneOf, `${objectName}.${prop}(oneOf).${i}`)\r",
+									"                });\r",
+									"            }\r",
+									"            else if (property.allOf) {\r",
+									"                _.forEach(property.allOf, (allOf, i) => {\r",
+									"                    testSchemaObject(schema, allOf, `${objectName}.${prop}(allOf).${i}`)\r",
+									"                });\r",
+									"            }\r",
+									"            else if (property.anyOf) {\r",
+									"                _.forEach(property.anyOf, (anyOf, i) => {\r",
+									"                    testSchemaObject(schema, anyOf, `${objectName}.${prop}(anyOf).${i}`)\r",
+									"                });\r",
+									"            }\r",
+									"            else {\r",
+									"                if (requireParamDescription && !property.$ref) {\r",
+									"                    pm.test(`Schema property '${objectName}.${prop}' has a description between ${paramDescriptionMinLength} and ${paramDescriptionMaxLength} characters`, function () {\r",
+									"                        pm.expect(property).to.have.property('description').and.to.be.a('string');\r",
+									"                        pm.expect(property.description.length).to.be.at.least(paramDescriptionMinLength);\r",
+									"                        pm.expect(property.description.length).to.be.at.most(paramDescriptionMaxLength);\r",
+									"                    });\r",
+									"\r",
+									"                    if (property.description) {\r",
+									"                        pm.test(`Schema property '${objectName}.${prop}' description is not just the name`, function () {\r",
+									"                            pm.expect(prop.toLowerCase()).to.not.equal(property.description.toLowerCase());\r",
+									"                        });\r",
+									"                    }\r",
+									"                }\r",
+									"\r",
+									"                if (requireParamExample && !property.$ref) {\r",
+									"                    pm.test(`Schema property '${objectName}.${prop}' has an example`, function () {\r",
+									"                        pm.expect(property).to.have.property('example');\r",
+									"                    });\r",
+									"                }\r",
+									"            }\r",
+									"        }\r",
+									"    }\r",
+									"    else if (object.type && object.type.toLowerCase() == 'array') {\r",
+									"        pm.test(`Schema '${objectName}' has items defined`, function () {\r",
+									"            pm.expect(object).to.have.property('items');\r",
+									"        });\r",
+									"\r",
+									"        testSchemaObject(schema, object.items, `${objectName}.list`);\r",
+									"    }\r",
+									"    else if (object.oneOf) {\r",
+									"        handleSchemaArray(schema, object, objectName, 'oneOf');\r",
+									"    } else if (object.allOf) {\r",
+									"        handleSchemaArray(schema, object, objectName, 'allOf');\r",
+									"    }\r",
+									"    else if (object.anyOf) {\r",
+									"        handleSchemaArray(schema, object, objectName, 'anyOf');\r",
+									"    }\r",
+									"    else if (object.$ref) {\r",
+									"        const name = getName(object.$ref);\r",
+									"        const testedRef = testedSchemaRefs.find(tsr => tsr == name);\r",
+									"        if (!testedRef) {\r",
+									"            testSchemaObject(schema, schema.components.schemas[name], objectName);\r",
+									"            testedSchemaRefs.push(name);\r",
+									"        }\r",
+									"    }\r",
+									"    else {\r",
+									"        pm.test(`Schema '${objectName}' has a declared type`, function () {\r",
+									"            pm.expect(object).to.have.property('type');\r",
+									"        });\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"function handleSchemaArray(schema, object, objectName, arrayType) {\r",
+									"    for (let i = 0; i < object[arrayType].length; i++) {\r",
+									"        const arraySchema = object[arrayType][i];\r",
+									"        if (arraySchema.$ref) {\r",
+									"            const name = getName(arraySchema.$ref);\r",
+									"            const testedRef = testedSchemaRefs.find(tsr => tsr == name);\r",
+									"            if (!testedRef) {\r",
+									"                testSchemaObject(schema, schema.components.schemas[name], `${objectName}[${i}](ref ${name})`);\r",
+									"                testedSchemaRefs.push(name);\r",
+									"            }\r",
+									"        }\r",
+									"        else {\r",
+									"            testSchemaObject(schema, arraySchema, `${objectName}[${i}]`);\r",
+									"        }\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"function getName(ref) {\r",
+									"    let pieces = ref.split('/');\r",
+									"    return pieces[pieces.length - 1];\r",
+									"}\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://postman-echo.com/delay/0",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"delay",
+								"0"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Contract Tests",
+			"item": [
+				{
+					"name": "Build Schema Tests",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
+									"\r",
+									"let schemaTests = [];    \r",
+									"for(let prop in schema.paths){\r",
+									"    const pathName = prop;    \r",
+									"    let path = {\r",
+									"        path: `${pm.collectionVariables.get('coll-baseUrl')}${pathName}`,\r",
+									"        parameters: schema.paths[prop].parameters,        \r",
+									"    };\r",
+									"\r",
+									"    for(let method in schema.paths[prop]){\r",
+									"        if(method.toLowerCase() == 'parameters' || isMockEndpoint(schema.paths[prop][method])){\r",
+									"            continue;\r",
+									"        }       \r",
+									"\r",
+									"        let currentPath = _.cloneDeep(path);\r",
+									"        currentPath.method = method.toUpperCase(); \r",
+									"        let pathMethod = schema.paths[prop][method];\r",
+									"        let securityExtension = pm.environment.get('env-securityExtensionName');        \r",
+									"        if(securityExtension && pathMethod[securityExtension] && pathMethod[securityExtension].length > 0){\r",
+									"            currentPath.allowedRole = pathMethod[securityExtension][0];\r",
+									"        }\r",
+									"\r",
+									"        if(pathMethod.parameters && pathMethod.parameters.length > 0) {\r",
+									"            if(currentPath.parameters) {\r",
+									"                currentPath.parameters = pathMethod.parameters.concat(pathMethod.parameters,currentPath.parameters);\r",
+									"            } else {\r",
+									"                currentPath.parameters = pathMethod.parameters;\r",
+									"            }\r",
+									"        }\r",
+									"\r",
+									"        const expectedResponses = getExpectedResponses(pathMethod);\r",
+									"        currentPath.responses = expectedResponses;\r",
+									"\r",
+									"        if(pathMethod.requestBody){\r",
+									"            let bodyModel;\r",
+									"            if(pathMethod.requestBody.content['application/json']) {\r",
+									"                if(pathMethod.requestBody.content['application/json'].schema && pathMethod.requestBody.content['application/json'].schema.$ref){\r",
+									"                    bodyModel = getSchemaReference(schema, pathMethod.requestBody.content['application/json'].schema.$ref);\r",
+									"                } else {\r",
+									"                    bodyModel = pathMethod.requestBody.content['application/json'].schema;\r",
+									"                }\r",
+									"            } else {\r",
+									"                continue;\r",
+									"            }\r",
+									"            \r",
+									"            const models = buildModels(schema, bodyModel);\r",
+									"            const mutations = buildModelMutations(models);\r",
+									"\r",
+									"            mutations.forEach((mutation) => {\r",
+									"                let schemaTest = _.cloneDeep(currentPath);\r",
+									"                Object.assign(schemaTest, mutation);\r",
+									"                schemaTest.name = `${schemaTest.method} - ${pathName} - ${schemaTest.description} - SUCCESS: ${schemaTest.success}`;\r",
+									"                schemaTests.push(schemaTest);\r",
+									"            });\r",
+									"        }        \r",
+									"        else {\r",
+									"            currentPath.name = `${currentPath.method} - ${pathName} - No Request Body - SUCCESS: true`;\r",
+									"            currentPath.success = true;\r",
+									"            schemaTests.push(currentPath);\r",
+									"        }\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"pm.collectionVariables.set('coll-schemaTests', JSON.stringify(schemaTests));\r",
+									"\r",
+									"//\r",
+									"// Supporting Methods Below\r",
+									"//\r",
+									"function buildModels(schema, object){\r",
+									"  let models = [];\r",
+									"\r",
+									"  if(object['$ref']){\r",
+									"    object = getSchemaReference(schema, object['$ref']);\r",
+									"  }\r",
+									"  \r",
+									"  if(object.type && object.type.toLowerCase() == 'object'){\r",
+									"    if(object.required && object.required.length > 0){ \r",
+									"      models.push({});\r",
+									"      _.forEach(object.required, function(param){\r",
+									"        const property = object.properties[param];\r",
+									"        \r",
+									"        if(property.type && ['string', 'number', 'integer', 'boolean'].includes(property.type.toLowerCase())){\r",
+									"          for(let modelIndex = 0; modelIndex < models.length; modelIndex++){\r",
+									"            let model = models[modelIndex];\r",
+									"            model[param] = property.example;\r",
+									"          }\r",
+									"        }\r",
+									"        else {\r",
+									"          const nestedObjects = buildModels(schema, property);          \r",
+									"          models = addToModels(models, nestedObjects, param);\r",
+									"        }                  \r",
+									"      });\r",
+									"    }\r",
+									"  }\r",
+									"  else if(object.type && object.type.toLowerCase() == 'array'){    \r",
+									"    let items = buildModels(schema, object.items);\r",
+									"    if(Array.isArray(items)){\r",
+									"      for(let i = 0; i < items.length; i++){\r",
+									"        models.push([items[i]]);\r",
+									"      }      \r",
+									"    }\r",
+									"    else {\r",
+									"      models.push([items]);\r",
+									"    }\r",
+									"  }\r",
+									"  else if (object.oneOf){  \r",
+									"    _.forEach(object.oneOf, function(component){\r",
+									"        let items = buildModels(schema, component);        \r",
+									"      models = models.concat(items);\r",
+									"    });    \r",
+									"  }\r",
+									"  else if (object.allOf){\r",
+									"    let pieces = [{}];\r",
+									"    _.forEach(object.allOf, function(component){\r",
+									"        let componentModels = buildModels(schema, component);\r",
+									"        pieces = addToModels(pieces, componentModels);        \r",
+									"    });\r",
+									"    \r",
+									"    models = pieces;\r",
+									"  }\r",
+									"  else if (object.anyOf){\r",
+									"      let pieces = [];\r",
+									"      let combinedPieces = [{}];\r",
+									"      _.forEach(object.anyOf, function(component){\r",
+									"        let componentModels = buildModels(schema, component);\r",
+									"        combinedPieces = addToModels(combinedPieces, componentModels);\r",
+									"        pieces = pieces.concat(componentModels);\r",
+									"      });\r",
+									"\r",
+									"      models = pieces.concat(combinedPieces);\r",
+									"  }\r",
+									"  else {\r",
+									"    // All other options are primitive values\r",
+									"    return object.example;\r",
+									"  }\r",
+									"  return models;\r",
+									"}\r",
+									"\r",
+									"function getSchemaReference(schema, referenceName){  \r",
+									"  const refPieces = referenceName.split('/');\r",
+									"  let reference = schema;\r",
+									"  for(let i = 1; i < refPieces.length; i++){\r",
+									"    reference = reference[refPieces[i]];\r",
+									"  }\r",
+									"\r",
+									"  return reference;  \r",
+									"}\r",
+									"\r",
+									"function addToModels(models, newPieces, name){\r",
+									"  let newModels = [];\r",
+									"  _.forEach(models, function(model){\r",
+									"    _.forEach(newPieces, function(newPiece){\r",
+									"      let newModel = _.cloneDeep(model);\r",
+									"      if(name){\r",
+									"        newModel[name] = newPiece;\r",
+									"      }\r",
+									"      else {\r",
+									"        Object.assign(newModel, newPiece);\r",
+									"      }\r",
+									"      newModels.push(newModel);\r",
+									"    });\r",
+									"  });\r",
+									"\r",
+									"  return newModels;\r",
+									"}\r",
+									"\r",
+									"function buildModelMutations(models){    \r",
+									"  let modelMutations = [];\r",
+									"  _.forEach(models, function(model){  \r",
+									"    addMutation(true, 'Has all required fields', model, modelMutations);\r",
+									"    let mutations = buildMutation(model);\r",
+									"    modelMutations = modelMutations.concat(mutations);\r",
+									"  });\r",
+									"\r",
+									"  return modelMutations;\r",
+									"}\r",
+									"\r",
+									"function buildMutation(model){\r",
+									"  let mutations = [];  \r",
+									"\r",
+									"  for(const [key, value] of Object.entries(model)){\r",
+									"    if(typeof value == 'object'){          \r",
+									"      let nestedMutations = buildMutation(value);\r",
+									"      nestedMutations.forEach((nestedMutation) => {\r",
+									"        let mutation = _.cloneDeep(model);\r",
+									"        mutation[key] = nestedMutation.body;\r",
+									"        addMutation(false, `${nestedMutation.description} in ${key} object`, mutation, mutations);\r",
+									"      });\r",
+									"      \r",
+									"      let mutation = _.cloneDeep(model);\r",
+									"      delete mutation[key];\r",
+									"      addMutation(false, `Missing ${key} object`, mutation, mutations);\r",
+									"\r",
+									"      let emptyMutation = _.cloneDeep(model);\r",
+									"      emptyMutation[key] = {};\r",
+									"      addMutation(false, `Empty ${key} object`, emptyMutation, mutations);\r",
+									"    }\r",
+									"    else {\r",
+									"      if(Array.isArray(value)){\r",
+									"        console.log('probably an error');\r",
+									"      }\r",
+									"      let mutation = _.cloneDeep(model);\r",
+									"      delete mutation[key];\r",
+									"      addMutation(false, `Missing ${key} property`, mutation, mutations);\r",
+									"\r",
+									"      let blankMutation = _.cloneDeep(model);\r",
+									"      blankMutation[key] = '';\r",
+									"      addMutation(false, `Blank ${key} property`, blankMutation, mutations);\r",
+									"    }\r",
+									"  }\r",
+									"\r",
+									"  return mutations;\r",
+									"}\r",
+									"\r",
+									"function addMutation(isSuccess, description, mutation, mutations){\r",
+									"  mutations.push({\r",
+									"    success: isSuccess, \r",
+									"    description: description,\r",
+									"    body: mutation\r",
+									"  });\r",
+									"}\r",
+									"\r",
+									"function getExpectedResponses(pathMethod){\r",
+									"    const responses = [];\r",
+									"        for(const [statusCode, value] of Object.entries(pathMethod.responses)){\r",
+									"            let response = {\r",
+									"                statusCode: Number(statusCode)\r",
+									"            };\r",
+									"\r",
+									"            if(value['x-postman-variables'] && Array.isArray(value['x-postman-variables'])){\r",
+									"                response.variables = value['x-postman-variables'].filter(variable => variable.type.toLowerCase() === 'save');\r",
+									"            }\r",
+									"\r",
+									"            if(value.$ref){\r",
+									"                response.$ref = value.$ref;                \r",
+									"            }\r",
+									"            else\r",
+									"            {\r",
+									"                if(value.content && value.content['application/json'] && value.content['application/json'].schema){\r",
+									"                    if(value.content['application/json'].schema.$ref){\r",
+									"                       response.$ref = value.content['application/json'].schema.$ref;                        \r",
+									"                    }\r",
+									"                    else {\r",
+									"                       response.schema = value.content['application/json'].schema;\r",
+									"                    }\r",
+									"                }\r",
+									"            }            \r",
+									"\r",
+									"            responses.push(response);\r",
+									"        }\r",
+									"    return responses;\r",
+									"}\r",
+									"\r",
+									"function isMockEndpoint(pathMethod){\r",
+									"    let isMock = false;\r",
+									"    if(pathMethod && pathMethod['x-amazon-apigateway-integration'] && pathMethod['x-amazon-apigateway-integration'].type \r",
+									"        && pathMethod['x-amazon-apigateway-integration'].type.toLowerCase() == 'mock') {\r",
+									"        isMock = true;\r",
+									"    }\r",
+									"\r",
+									"    return isMock;\r",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let schemaTests = pm.collectionVariables.get('coll-schemaTests');\r",
+									"if(schemaTests){\r",
+									"    schemaTests = JSON.parse(schemaTests);\r",
+									"    if(!schemaTests || !schemaTests.length){\r",
+									"        postman.setNextRequest('More APIs to Process?');\r",
+									"    }\r",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://postman-echo.com/delay/0",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"delay",
+								"0"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Test Request",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const url = require('url');\r",
+									"\r",
+									"const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
+									"let schemaTests = JSON.parse(pm.collectionVariables.get('coll-schemaTests'));\r",
+									"\r",
+									"const schemaTest = schemaTests.shift();\r",
+									"pm.collectionVariables.set('coll-schemaTests', JSON.stringify(schemaTests));\r",
+									"pm.variables.set('currentSchemaTest', JSON.stringify(schemaTest));\r",
+									"\r",
+									"const path = replacePathParameters(schema, schemaTest.path, schemaTest.parameters);\r",
+									"pm.request.url.update(path);\r",
+									"delete pm.request.url.auth;\r",
+									"delete pm.request.url.port;\r",
+									"delete pm.request.url.hash;\r",
+									"pm.request.url.protocol = pm.request.url.protocol.replace(/\\:$/, '');\r",
+									"pm.request.method = schemaTest.method;\r",
+									"pm.request.name = schemaTest.name;\r",
+									"\r",
+									"pm.variables.set('requestName', schemaTest.name);\r",
+									"pm.variables.set('body', JSON.stringify(schemaTest.body));\r",
+									"\r",
+									"// Add top level parameters from the path\r",
+									"const roleHeaderName = pm.environment.get('env-roleHeaderName');\r",
+									"\r",
+									"if(schemaTest.parameters){\r",
+									"    for(let i = 0; i < schemaTest.parameters.length; i++){\r",
+									"        let param = schemaTest.parameters[i];\r",
+									"\r",
+									"        if (param.$ref) {\r",
+									"            let pieces = param.$ref.split('/');\r",
+									"            const name = pieces[pieces.length-1];\r",
+									"            const schemaParam = schema.components.parameters[name];\r",
+									"            const paramType = schemaParam.in.toLowerCase();\r",
+									"            const paramValue = loadParameterValue(schemaParam);\r",
+									"            if(paramType == 'header'){\r",
+									"                if(roleHeaderName && schemaParam.name.toLowerCase() == roleHeaderName.toLowerCase()){\r",
+									"                    pm.request.headers.upsert({ key: schemaParam.name, value: schemaTest.allowedRole });    \r",
+									"                } \r",
+									"                else {\r",
+									"                    pm.request.headers.upsert({ key: schemaParam.name, value: paramValue });\r",
+									"                }\r",
+									"            } else if (paramType == 'query' && schemaParam.required == true) {\r",
+									"                pm.request.url.query.upsert({ key: schemaParam.name, value: paramValue });\r",
+									"            }\r",
+									"        } else {\r",
+									"            const paramType = param.in.toLowerCase();\r",
+									"            const paramValue = loadParameterValue(param);\r",
+									"            if (paramType == 'header') {\r",
+									"                pm.request.headers.upsert({ key: param.name, value: paramValue });\r",
+									"            } else if (paramType == 'query' && param.required == true) {\r",
+									"                pm.request.url.query.upsert({ key: param.name, value: paramValue });\r",
+									"            }\r",
+									"        }\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"function loadParameterValue(parameter){\r",
+									"    let parameterValue;\r",
+									"    if(parameter['x-postman-variables']){\r",
+									"        let variable = parameter['x-postman-variables'].find(v => v.type.toLowerCase() === 'load');\r",
+									"        if(variable && pm.collectionVariables.has(variable.name)){\r",
+									"            parameterValue = pm.collectionVariables.get(variable.name);\r",
+									"        }\r",
+									"        else {\r",
+									"            parameterValue = encodeURIComponent(parameter.schema.example ? parameter.schema.example : parameter.example);    \r",
+									"        }\r",
+									"    }\r",
+									"    else {\r",
+									"        parameterValue = encodeURIComponent(parameter.schema.example ? parameter.schema.example : parameter.example);\r",
+									"    }\r",
+									"\r",
+									"    return parameterValue;\r",
+									"}\r",
+									"\r",
+									"function replacePathParameters(schema, pathName, parameters){\r",
+									"    let replacedPathName = pathName;\r",
+									"    let pathVariableRegex = /{([^}]*)}/g;\r",
+									"    let matches = pathName.match(pathVariableRegex);\r",
+									"    _.forEach(matches, function(match){\r",
+									"        let paramName = match.substring(1, match.length - 1);\r",
+									"        _.forEach(parameters, function(param){\r",
+									"            if(param.$ref){\r",
+									"                let parameter = getSchemaReference(schema, param.$ref);                \r",
+									"                if (parameter.in && parameter.in.toLowerCase() == 'path' && parameter.name && parameter.name == paramName){\r",
+									"                    let parameterValue = loadParameterValue(parameter);\r",
+									"                    replacedPathName = replacedPathName.replace(match, parameterValue);\r",
+									"                    return false;\r",
+									"                }\r",
+									"            } else {\r",
+									"                if (param.in && param.in.toLowerCase() == 'path' && param.name && param.name == paramName) {\r",
+									"                    let parameterValue = loadParameterValue(param);\r",
+									"                    replacedPathName = replacedPathName.replace(match, parameterValue);\r",
+									"                    return false;\r",
+									"                }\r",
+									"            }\r",
+									"        });    \r",
+									"    });\r",
+									"\r",
+									"    return url.parse(replacedPathName);\r",
+									"}\r",
+									"\r",
+									"function getSchemaReference(schema, referenceName){  \r",
+									"  const refPieces = referenceName.split('/');\r",
+									"  let reference = schema;\r",
+									"  for(let i = 1; i < refPieces.length; i++){\r",
+									"    reference = reference[refPieces[i]];\r",
+									"  }\r",
+									"\r",
+									"  return reference;  \r",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const schemaTests = JSON.parse(pm.collectionVariables.get('coll-schemaTests'));\r",
+									"if(schemaTests.length > 0){\r",
+									"    postman.setNextRequest('Test Request');\r",
+									"}\r",
+									"\r",
+									"const schemaTest = JSON.parse(pm.variables.get('currentSchemaTest'));\r",
+									"\r",
+									"pm.test(`${schemaTest.name} - Has expected status code`, function () {\r",
+									"    if(schemaTest.success){\r",
+									"        pm.expect(pm.response.code).to.not.equal(400);\r",
+									"    }\r",
+									"    else {\r",
+									"        pm.response.to.have.status(400);\r",
+									"    }    \r",
+									"});\r",
+									"\r",
+									"\r",
+									"const expectedResponse = schemaTest.responses.find(r => r.statusCode == pm.response.code);\r",
+									"pm.test(`${schemaTest.name} - Status code is allowed`, function(){\r",
+									"    pm.expect(expectedResponse).to.exist;\r",
+									"});\r",
+									"\r",
+									"if(expectedResponse){\r",
+									"    pm.test(`${schemaTest.name} - Has expected response body schema`, function(){\r",
+									"        const Ajv = require('ajv');\r",
+									"        const ajv = new Ajv({allErrors: true,format: false});\r",
+									"        \r",
+									"        if(pm.response.code == 204 || shouldResponseBeEmpty(expectedResponse)){\r",
+									"            checkForEmptyResponse();\r",
+									"        }\r",
+									"        else if(expectedResponse.$ref){            \r",
+									"            const jsonData = pm.response.json();\r",
+									"            const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
+									"            ajv.addSchema(schema, 'OAS');\r",
+									"            \r",
+									"            const valid = ajv.validate({$ref: `OAS${expectedResponse.$ref}`}, jsonData);\r",
+									"            const errors = ajv.errorsText(valid.errors);\r",
+									"            pm.expect(errors).to.equal('No errors');\r",
+									"            if(errors !== 'No errors'){\r",
+									"                console.log(errors);\r",
+									"            }\r",
+									"        }\r",
+									"        else if(expectedResponse.schema){\r",
+									"            const jsonData = pm.response.json();\r",
+									"            const validate = ajv.compile(expectedResponse.schema);\r",
+									"            const valid = validate(jsonData);\r",
+									"            const errors = ajv.errorsText(valid.errors);\r",
+									"            pm.expect(errors).to.equal('No errors');\r",
+									"            if(errors !== 'No errors'){\r",
+									"                console.log(errors);\r",
+									"            }\r",
+									"        }\r",
+									"        else {\r",
+									"            checkForEmptyResponse();\r",
+									"        }\r",
+									"\r",
+									"        if(expectedResponse.variables){\r",
+									"            const jsonData = pm.response.json();\r",
+									"            _.forEach(expectedResponse.variables, function(variable){\r",
+									"                let pathPieces = variable.path.split('.').filter(piece => piece);\r",
+									"                let data = jsonData;\r",
+									"                let found = true;\r",
+									"                _.forEach(pathPieces, function(piece){\r",
+									"                    if(data[piece]){\r",
+									"                        data = data[piece];\r",
+									"                    }\r",
+									"                    else {\r",
+									"                        found = false;\r",
+									"                    }\r",
+									"                });\r",
+									"\r",
+									"                if(found){\r",
+									"                    pm.collectionVariables.set(variable.name, data);\r",
+									"                }\r",
+									"                else {\r",
+									"                    pm.test(`Unable to save dynamic variable ${variable.name} at the provided path.`, function() {\r",
+									"                        pm.expect(true).to.equal(variable.path);\r",
+									"                    });\r",
+									"                }\r",
+									"            });\r",
+									"        }\r",
+									"    });\r",
+									"}\r",
+									"\r",
+									"function checkForEmptyResponse() {\r",
+									"    let emptyBody = true;\r",
+									"    if(pm.response.text()){\r",
+									"        emptyBody = false; \r",
+									"    }\r",
+									"\r",
+									"    pm.expect(emptyBody).to.be.true;\r",
+									"}\r",
+									"\r",
+									"function shouldResponseBeEmpty(expectedResponse){\r",
+									"    let responseSchema = expectedResponse.schema;\r",
+									"    if(expectedResponse.$ref){\r",
+									"        let schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
+									"        responseSchema = getSchemaReference(schema, expectedResponse.$ref);\r",
+									"        if(expectedResponse.$ref.startsWith('#/components/responses')){\r",
+									"            return (!responseSchema || !responseSchema.content || !responseSchema.content['application/json'] \r",
+									"                || !responseSchema.content['application/json'].schema || Object.keys(responseSchema.content['application/json'].schema).length == 0);\r",
+									"        } else {\r",
+									"            return false;\r",
+									"        }\r",
+									"    }\r",
+									"    else {\r",
+									"        return (responseSchema === undefined || Object.keys(responseSchema).length == 0);\r",
+									"    }\r",
+									"}\r",
+									"\r",
+									"function getSchemaReference(schema, referenceName){  \r",
+									"  const refPieces = referenceName.split('/');\r",
+									"  let reference = schema;\r",
+									"  for(let i = 1; i < refPieces.length; i++){\r",
+									"    reference = reference[refPieces[i]];\r",
+									"  }\r",
+									"\r",
+									"  return reference;  \r",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{{body}}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://postman-echo.com/get",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"get"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Finalize",
+			"item": [
+				{
+					"name": "More APIs to Process?",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let apis = pm.collectionVariables.get('coll-apiIds');\r",
+									"if(apis){\r",
+									"    try{\r",
+									"        apis = JSON.parse(apis);\r",
+									"        if(apis.length > 0){\r",
+									"            postman.setNextRequest('Get Current API Version');\r",
+									"        }\r",
+									"    }\r",
+									"    catch(err){}    \r",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://postman-echo.com/delay/0",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"delay",
+								"0"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Remove Test Variables",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// See https://blog.postman.com/2019/05/28/pro-tip-dynamically-unset-postman-environment-variables/\r",
+									"// for more details on what we're doing here. \r",
+									"\r",
+									"cleanupCollectionVariables();\r",
+									"\r",
+									"function cleanupCollectionVariables() {\r",
+									"    const clean = _.keys(pm.collectionVariables.toObject());\r",
+									"\r",
+									"    _.each(clean, (arrItem) => {\r",
+									"        pm.collectionVariables.unset(arrItem);\r",
+									"    });\r",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://postman-echo.com/delay/0",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"delay",
+								"0"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
 }

--- a/test/contractTests-GET-anyOf.js
+++ b/test/contractTests-GET-anyOf.js
@@ -9,7 +9,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST001 - GET Full Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3555
+      const PORT = 3600
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST001'
@@ -65,11 +65,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3555/schema'
+              value: 'http://localhost:3600/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3555'
+              value: 'http://localhost:3600'
             }
           ]
         })
@@ -115,7 +115,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST002 - GET Partial Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3556
+      const PORT = 3601
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST002'
@@ -165,11 +165,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3556/schema'
+              value: 'http://localhost:3601/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3556'
+              value: 'http://localhost:3601'
             }
           ]
         })
@@ -215,7 +215,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST003 - GET Neither Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3557
+      const PORT = 3602
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST003'
@@ -265,11 +265,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3557/schema'
+              value: 'http://localhost:3602/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3557'
+              value: 'http://localhost:3602'
             }
           ]
         })
@@ -315,7 +315,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST004 - GET Both Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3558
+      const PORT = 3603
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST004'
@@ -372,11 +372,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3558/schema'
+              value: 'http://localhost:3603/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3558'
+              value: 'http://localhost:3603'
             }
           ]
         })

--- a/test/contractTests-GET-oneOf.js
+++ b/test/contractTests-GET-oneOf.js
@@ -9,7 +9,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST001 - GET Full Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3555
+      const PORT = 3700
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST001'
@@ -65,11 +65,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3555/schema'
+              value: 'http://localhost:3700/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3555'
+              value: 'http://localhost:3700'
             }
           ]
         })
@@ -115,7 +115,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST002 - GET Partial Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3556
+      const PORT = 3701
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST002'
@@ -165,11 +165,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3556/schema'
+              value: 'http://localhost:3701/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3556'
+              value: 'http://localhost:3701'
             }
           ]
         })
@@ -215,7 +215,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST003 - GET Neither Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3557
+      const PORT = 3702
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST003'
@@ -265,11 +265,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3557/schema'
+              value: 'http://localhost:3702/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3557'
+              value: 'http://localhost:3702'
             }
           ]
         })
@@ -315,7 +315,7 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
   describe('TEST004 - GET Both Product Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3558
+      const PORT = 3703
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST004'
@@ -372,11 +372,11 @@ describe('Postman Contract Test Suite - GET OneOf Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3558/schema'
+              value: 'http://localhost:3703/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3558'
+              value: 'http://localhost:3703'
             }
           ]
         })

--- a/test/contractTests-GET.js
+++ b/test/contractTests-GET.js
@@ -9,7 +9,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
   describe('TEST001 - GET Valid Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3555
+      const PORT = 3900
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST001'
@@ -65,11 +65,11 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3555/schema'
+              value: 'http://localhost:3900/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3555'
+              value: 'http://localhost:3900'
             }
           ]
         })
@@ -115,7 +115,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
   describe('TEST002 - GET Missing Required Response Property', () => {
     let test002MockServer = null
     before('setup mock server', done => {
-      const PORT = 3556
+      const PORT = 3901
 
       console.log('Setting up a new mock server')
       test002MockServer = PostmanMockBuilder.create({
@@ -174,11 +174,11 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3556/schema'
+              value: 'http://localhost:3901/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3556'
+              value: 'http://localhost:3901'
             }
           ]
         })
@@ -220,7 +220,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
   describe('TEST003 - GET Undefined Required Response Property', () => {
     let test003MockServer = null
     before('setup mock server', done => {
-      const PORT = 3557
+      const PORT = 3902
 
       console.log('Setting up a new mock server')
       test003MockServer = PostmanMockBuilder.create({
@@ -279,11 +279,11 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3557/schema'
+              value: 'http://localhost:3902/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3557'
+              value: 'http://localhost:3902'
             }
           ]
         })
@@ -325,7 +325,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
   describe('TEST004 - GET Invalid Required Response Property', () => {
     let test004MockServer = null
     before('setup mock server', done => {
-      const PORT = 3558
+      const PORT = 3903
 
       console.log('Setting up a new mock server')
       test004MockServer = PostmanMockBuilder.create({
@@ -384,11 +384,11 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3558/schema'
+              value: 'http://localhost:3903/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3558'
+              value: 'http://localhost:3903'
             }
           ]
         })
@@ -430,7 +430,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
   describe('TEST005 - GET Missing Optional Response Property', () => {
     let test005MockServer = null
     before('setup mock server', done => {
-      const PORT = 3559
+      const PORT = 3904
 
       console.log('Setting up a new mock server')
       test005MockServer = PostmanMockBuilder.create({
@@ -488,11 +488,11 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3559/schema'
+              value: 'http://localhost:3904/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3559'
+              value: 'http://localhost:3904'
             }
           ]
         })
@@ -534,7 +534,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
   describe('TEST006 - GET Undefined Optional Response Property', () => {
     let test006MockServer = null
     before('setup mock server', done => {
-      const PORT = 3560
+      const PORT = 3905
 
       console.log('Setting up a new mock server')
       test006MockServer = PostmanMockBuilder.create({
@@ -593,11 +593,11 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3560/schema'
+              value: 'http://localhost:3905/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3560'
+              value: 'http://localhost:3905'
             }
           ]
         })
@@ -639,7 +639,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
   describe('TEST007 - GET Invalid Optional Response Property', () => {
     let test007MockServer = null
     before('setup mock server', done => {
-      const PORT = 3561
+      const PORT = 3906
 
       console.log('Setting up a new mock server')
       test007MockServer = PostmanMockBuilder.create({
@@ -698,11 +698,11 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3561/schema'
+              value: 'http://localhost:3906/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3561'
+              value: 'http://localhost:3906'
             }
           ]
         })

--- a/test/contractTests-POST.js
+++ b/test/contractTests-POST.js
@@ -9,7 +9,7 @@ describe('Postman Contract Test Suite - POST Requests', () => {
   describe('TEST001 - POST Valid Response', () => {
     let test001MockServer = null
     before('setup mock server', done => {
-      const PORT = 3555
+      const PORT = 4000
 
       test001MockServer = PostmanMockBuilder.create({
         apiVersion: 'TEST001'
@@ -165,11 +165,11 @@ describe('Postman Contract Test Suite - POST Requests', () => {
           envVar: [
             {
               key: 'env-schemaUrl',
-              value: 'http://localhost:3555/schema'
+              value: 'http://localhost:4000/schema'
             },
             {
               key: 'env-server',
-              value: 'http://localhost:3555'
+              value: 'http://localhost:4000'
             }
           ]
         })

--- a/test/schemas/sample-product-GET-schema-anyOf.json
+++ b/test/schemas/sample-product-GET-schema-anyOf.json
@@ -6,16 +6,16 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3555",
+      "url": "http://localhost:3600",
       "description": "Test Server"
     },{
-      "url": "http://localhost:3556",
+      "url": "http://localhost:3601",
       "description": "Test Server"
     },{
-      "url": "http://localhost:3557",
+      "url": "http://localhost:3602",
       "description": "Test Server"
     },{
-      "url": "http://localhost:3558",
+      "url": "http://localhost:3603",
       "description": "Test Server"
     }
   ],

--- a/test/schemas/sample-product-GET-schema-oneOf.json
+++ b/test/schemas/sample-product-GET-schema-oneOf.json
@@ -6,16 +6,16 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3555",
+      "url": "http://localhost:3700",
       "description": "Test Server"
     },{
-      "url": "http://localhost:3556",
+      "url": "http://localhost:3701",
       "description": "Test Server"
     },{
-      "url": "http://localhost:3557",
+      "url": "http://localhost:3702",
       "description": "Test Server"
     },{
-      "url": "http://localhost:3558",
+      "url": "http://localhost:3703",
       "description": "Test Server"
     }
   ],

--- a/test/schemas/sample-product-GET-schema.json
+++ b/test/schemas/sample-product-GET-schema.json
@@ -6,55 +6,55 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3555",
+      "url": "http://localhost:3900",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3556",
+      "url": "http://localhost:3901",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3557",
+      "url": "http://localhost:3902",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3558",
+      "url": "http://localhost:3903",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3559",
+      "url": "http://localhost:3904",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3560",
+      "url": "http://localhost:3905",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3561",
+      "url": "http://localhost:3906",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3562",
+      "url": "http://localhost:3907",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3563",
+      "url": "http://localhost:3908",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3564",
+      "url": "http://localhost:3909",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3565",
+      "url": "http://localhost:3910",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3566",
+      "url": "http://localhost:3911",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3567",
+      "url": "http://localhost:3912",
       "description": "Test Server"
     }
   ],

--- a/test/schemas/sample-product-POST-schema.json
+++ b/test/schemas/sample-product-POST-schema.json
@@ -6,55 +6,15 @@
   },
   "servers": [
     {
-      "url": "http://localhost:3555",
+      "url": "http://localhost:4000",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3556",
+      "url": "http://localhost:4001",
       "description": "Test Server"
     },
     {
-      "url": "http://localhost:3557",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3558",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3559",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3560",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3561",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3562",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3563",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3564",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3565",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3566",
-      "description": "Test Server"
-    },
-    {
-      "url": "http://localhost:3567",
+      "url": "http://localhost:4002",
       "description": "Test Server"
     }
   ],


### PR DESCRIPTION
Fixes a bug where if the `env-schemaUrl` wasn't provided this would throw an error.

Also improves the testing automation to allow all test scripts to be run in sequence by using different ports for the local test implementation servers.