### PR TITLE
Updated the env-apiIds parameter to be env-apiId parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,17 +257,5 @@ Below is a list of environment variables currently consumed by the generator:
 * `env-schemaPropertyExceptions` - The names of any properties that should not be validated in the component tests - **ARRAY OF STRINGS**
 * `env-jsonToYaml` - NPM Package that converts yaml to json. DO NOT EDIT!
 
-# Contact
-You may contact me by any of the social media channels below:
-
-[![Twitter][1.1]][1] [![GitHub][2.1]][2] [![LinkedIn][3.1]][3] [![Ready, Set, Cloud!][4.1]][4]
-
-[1.1]: http://i.imgur.com/tXSoThF.png
-[2.1]: http://i.imgur.com/0o48UoR.png
-[3.1]: http://i.imgur.com/lGwB1Hk.png
-[4.1]: https://readysetcloud.s3.amazonaws.com/logo.png
-
-[1]: http://www.twitter.com/allenheltondev
-[2]: http://www.github.com/allenheltondev
-[3]: https://www.linkedin.com/in/allen-helton-85aa9650/
-[4]: https://readysetcloud.io
+# Issues
+Please raise any issues in this repository. Be sure to include as much detail as possible.

--- a/src/v2/Contract Test Generator.postman_collection.json
+++ b/src/v2/Contract Test Generator.postman_collection.json
@@ -2,8 +2,10 @@
 	"info": {
 		"_postman_id": "0aea1b32-b8a3-42ae-be65-d509e926516e",
 		"name": "(Generator) Contract Tests - OAS2 / Swagger",
-		"description": "This collection will automatically generate a series of tests against an OpenAPI2 / Swagger definition that is within your API Builder in Postman.\n\n## Getting Started\n\nRead the documentation on the [Contract Testing Public Workspace](https://postman.postman.co/workspace/0bc7d76d-b582-45ba-b216-5da2c1d174a0) to get started.\n\n## Running this collection\n\nFirstly, make sure you have set up your environment variables by forking [this environment](https://postman.postman.co/workspace/Contract-Test-Generator~0bc7d76d-b582-45ba-b216-5da2c1d174a0/environment/18354885-1125d62a-154a-45a6-8b04-73073e8e4d16). Once completed, this collection can be run using the Postman collection runner or from Newman.\n\n### Change Log\n\n#### 2024-06-07\n\n- Updated to use Postman v10 API endpoints\n    \n- Added support for a new `env-apiIds` environment variable that allows users to set a comma separated list of Postman API IDs that are present in the supplied workspace to be processed by the test generator.\n    \n\n#### 2023-10-01\n\n- Added support for the env-schemaUrl environment variable enabling you to supply a URL to a JSON or YAML based schema for validation.\n    \n- Various bug fixes and improvements for performance.\n    \n\n## Support\n\nThis collection is maintained in GitHub by the Postman Solutions Engineering team. Please post an issue directly in [this GitHub project](https://github.com/postman-solutions-eng/postman-contract-test-generator) if you need support.",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"description": "This collection will automatically generate a series of tests against an OpenAPI2 / Swagger definition that is within your API Builder in Postman or supplied from an external URL.\n\n## Getting Started\n\nRead the documentation on the [Contract Testing Public Workspace](https://postman.postman.co/workspace/0bc7d76d-b582-45ba-b216-5da2c1d174a0) to get started.\n\n## Running this collection\n\nFirstly, make sure you have set up your environment variables by forking [this environment](https://postman.postman.co/workspace/Contract-Test-Generator~0bc7d76d-b582-45ba-b216-5da2c1d174a0/environment/18354885-1125d62a-154a-45a6-8b04-73073e8e4d16). Once completed, this collection can be run using the Postman collection runner or from Newman.\n\n### Change Log\n\n#### 2024-06-14\n\n- Merged PR [#15](https://github.com/postman-solutions-eng/postman-contract-test-generator/pull/15)\n    \n- Updated the generator to remove deprecated Postman V9 endpoints in favor of Postman v10 API endpoints.\n    \n- Added support for new `env-apiId` and `env-apiDefinitionId` environment variables that allow users to set a specific Postman API ID that is present in the supplied workspace to be processed by the test generator.\n    \n\n**Breaking Changes:**\n\nThe update to the v10 API endpoints results in the following changes required by users:\n\n- When referencing an API from Postman, the API **must** either have a [published version](https://learning.postman.com/docs/designing-and-developing-your-api/versioning-an-api/api-versions/) inside Postman, or the environment must supply the new `env-apiId` and `env-apiDefinitionId` parameters.\n    \n- This does not affect users that reference external schemas from the `env-schemaUrl` environment variable.\n    \n- Users that don't have a published version, or supply the parameters will receive an error: `API must have a published version or a definitionId provided`.\n    \n\n#### 2023-10-01\n\n- Added support for the env-schemaUrl environment variable enabling you to supply a URL to a JSON or YAML based schema for validation.\n    \n- Various bug fixes and improvements for performance.\n    \n\n## Support\n\nThis collection is maintained in GitHub by the Postman Solutions Engineering team. Please post an issue directly in [this GitHub project](https://github.com/postman-solutions-eng/postman-contract-test-generator) if you need support.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18354885",
+		"_collection_link": "https://postman.postman.co/workspace/Contract-Test-Generator---OAS2-~c3ed36bd-a29e-496c-be25-3bf6b0c9d171/collection/18354885-0aea1b32-b8a3-42ae-be65-d509e926516e?action=share&source=collection_link&creator=18354885"
 	},
 	"item": [
 		{
@@ -189,27 +191,23 @@
 									"script": {
 										"exec": [
 											"//2024-06-07 - Added new environment variable for targeting specific API ID\r",
-											"let targetApiIds = pm.environment.get('env-apiIds');\r",
+											"let targetApiId = pm.environment.get('env-apiId');\r",
 											"let apiIds = [];\r",
 											"\r",
-											"if(targetApiIds && targetApiIds.length > 0) {\r",
+											"if(targetApiId && targetApiId != \"\") {\r",
 											"    //User has targeted at least 1 API in this workspace.\r",
-											"    targetApiIds = targetApiIds.split(\",\").map(function(item) {\r",
-											"        return item.trim();\r",
-											"    });\r",
+											"    targetApiId = targetApiId.trim();\r",
 											"\r",
 											"    //Validate that the API IDs provided exist in this workspace.\r",
 											"    let workspaceApiIds = pm.response.json().apis.map(api => api.id);\r",
 											"\r",
 											"    console.log(workspaceApiIds);\r",
 											"\r",
-											"    targetApiIds.forEach(targetApi => {\r",
-											"        pm.test(`Validate that API ${targetApi} exists in this workspace.`, function () {    \r",
-											"            pm.expect(workspaceApiIds, \"Your env-apiIds variable includes an invalid API ID\").to.include(targetApi);\r",
-											"        });\r",
-											"    })\r",
+											"    pm.test(`Validate that API ${targetApiId} exists in this workspace.`, function () {    \r",
+											"        pm.expect(workspaceApiIds, \"Your env-apiIds variable includes an invalid API ID\").to.include(targetApiId);\r",
+											"    });\r",
 											"\r",
-											"    apiIds = targetApiIds;\r",
+											"    apiIds = [targetApiId];\r",
 											"\r",
 											"    pm.test(`There is at least 1 API to process`, function() {\r",
 											"        pm.expect(apiIds).to.have.length.greaterThan(0);\r",
@@ -281,14 +279,37 @@
 									"script": {
 										"exec": [
 											"const jsonData = pm.response.json();\r",
+											"let latestVersionId;\r",
+											"let apiDefinitionId;\r",
 											"\r",
-											"pm.test('API has one or more versions', function(){\r",
-											"    pm.expect(jsonData).to.have.property('versions').and.to.be.an('array');\r",
-											"    pm.expect(jsonData.versions.length).to.be.above(0);\r",
-											"});\r",
+											"//set the latest version\r",
+											"if(jsonData && jsonData.versions && jsonData.versions.length > 0) {\r",
+											"    latestVersionId = jsonData.versions[0].id;\r",
+											"}\r",
 											"\r",
-											"const version = jsonData.versions[0];\r",
-											"pm.collectionVariables.set('coll-versionId', version.id);"
+											"if(latestVersionId) {\r",
+											"    pm.collectionVariables.set('coll-versionId', latestVersionId);\r",
+											"} \r",
+											"\r",
+											"//We have no published versions - see if we can get the schema via the supplied definitionId\r",
+											"apiId = pm.environment.get(\"env-apiId\");\r",
+											"apiDefinitionId = pm.environment.get(\"env-apiDefinitionId\");\r",
+											"\r",
+											"if(apiId && apiDefinitionId && apiId != \"\" && apiDefinitionId != \"\") {\r",
+											"    pm.collectionVariables.set(\"coll-schemaId\", apiDefinitionId);\r",
+											"    postman.setNextRequest(\"Get API Schema\");\r",
+											"}\r",
+											"\r",
+											"pm.test(\"API must have at least 1 version published or a definitionId provided.\", function() {\r",
+											"    postman.setNextRequest(null);\r",
+											"    pm.expect(latestVersionId || apiDefinitionId, \"API does not have a published version, and no definitionId is available in the environment\").to.not.be.undefined;\r",
+											"    \r",
+											"    if (apiDefinitionId) {\r",
+											"        postman.setNextRequest(\"Get API Schema\")\r",
+											"    } else if(latestVersionId) {\r",
+											"        postman.setNextRequest(\"Get Current API Schema\");\r",
+											"    }\r",
+											"})"
 										],
 										"type": "text/javascript",
 										"packages": {}
@@ -1266,7 +1287,8 @@
 									"  return reference;  \r",
 									"}"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						},
 						{
@@ -1319,7 +1341,7 @@
 									"            const jsonData = pm.response.json();\r",
 									"            const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
 									"            ajv.addSchema(schema, 'OAS');\r",
-									"            expectedResponse.schema.items.$ref = `OAS${expectedResponse.schema.items.$ref}`",
+									"            expectedResponse.schema.items.$ref = `OAS${expectedResponse.schema.items.$ref}`\r",
 									"            const valid = ajv.validate(expectedResponse.schema, jsonData);\r",
 									"            const errors = ajv.errorsText(valid.errors);\r",
 									"            pm.expect(errors).to.equal('No errors');\r",
@@ -1405,7 +1427,8 @@
 									"  return reference;  \r",
 									"}"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],

--- a/src/v3/Contract Test Generator.postman_collection.json
+++ b/src/v3/Contract Test Generator.postman_collection.json
@@ -1,9 +1,11 @@
 {
 	"info": {
-		"_postman_id": "9e909e94-e165-430a-8806-cd5f149be6c2",
+		"_postman_id": "42982379-6212-43b9-a980-7f0354ea978c",
 		"name": "(Generator) Contract Tests - OAS3",
-		"description": "This collection will automatically generate a series of tests against an OpenAPI3 definition that is within your API Builder in Postman.\n\n## Getting Started\n\nRead the documentation on the [Contract Testing Public Workspace](https://postman.postman.co/workspace/0bc7d76d-b582-45ba-b216-5da2c1d174a0) to get started.\n\n## Running this collection\n\nFirstly, make sure you have set up your environment variables by forking [this environment](https://postman.postman.co/workspace/Contract-Test-Generator~0bc7d76d-b582-45ba-b216-5da2c1d174a0/environment/18354885-1125d62a-154a-45a6-8b04-73073e8e4d16). Once completed, this collection can be run using the Postman collection runner, Postman CLI, or from Newman.\n\n### Change Log\n\n#### 2024-06-07\n\n- Updated to use Postman v10 API endpoints\n    \n- Added support for a new `env-apiIds` environment variable that allows users to set a comma separated list of Postman API IDs that are present in the supplied workspace to be processed by the test generator.\n    \n\n#### 2023-08-08\n\n**Added support for retrieving schema from a URL from CLI.**\n\nYou can now supply the `env-schemaUrl` property either via the environment or via the CLI. This will cause the collection to retrieve the API specification from the supplied URL instead of attempting to fetch it from the Postman workspace.\n\n## Support\n\nThis collection is maintained in GitHub by the Postman Solutions Engineering team. Please post an issue directly in [this GitHub project](https://github.com/postman-solutions-eng/postman-contract-test-generator) if you need support.",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"description": "This collection will automatically generate a series of tests against an OpenAPI3 definition that is within your API Builder in Postman.\n\n## Getting Started\n\nRead the documentation on the [Contract Testing Public Workspace](https://postman.postman.co/workspace/0bc7d76d-b582-45ba-b216-5da2c1d174a0) to get started.\n\n## Running this collection\n\nFirstly, make sure you have set up your environment variables by forking [this environment](https://postman.postman.co/workspace/Contract-Test-Generator~0bc7d76d-b582-45ba-b216-5da2c1d174a0/environment/18354885-1125d62a-154a-45a6-8b04-73073e8e4d16). Once completed, this collection can be run using the Postman collection runner, Postman CLI, or from Newman.\n\n### Change Log\n\n#### 2024-06-14\n\n- Merged PR [#15](https://github.com/postman-solutions-eng/postman-contract-test-generator/pull/15)\n    \n- Updated the generator to remove deprecated Postman V9 endpoints in favor of Postman v10 API endpoints.\n    \n- Added support for new `env-apiId` and `env-apiDefinitionId` environment variables that allow users to set a specific Postman API ID that is present in the supplied workspace to be processed by the test generator.\n    \n\n**Breaking Changes:**\n\nThe update to the v10 API endpoints results in the following changes required by users:\n\n- When referencing an API from Postman, the API **must** either have a [published version](https://learning.postman.com/docs/designing-and-developing-your-api/versioning-an-api/api-versions/) inside Postman, or the environment must supply the new `env-apiId` and `env-apiDefinitionId` parameters.\n    \n- This does not affect users that reference external schemas from the `env-schemaUrl` environment variable.\n    \n- Users that don't have a published version, or supply the parameters will receive an error: `API must have a published version or a definitionId provided`.\n    \n\n#### 2023-08-08\n\n**Added support for retrieving schema from a URL from CLI.**\n\nYou can now supply the `env-schemaUrl` property either via the environment or via the CLI. This will cause the collection to retrieve the API specification from the supplied URL instead of attempting to fetch it from the Postman workspace.\n\n## Support\n\nThis collection is maintained in GitHub by the Postman Solutions Engineering team. Please post an issue directly in [this GitHub project](https://github.com/postman-solutions-eng/postman-contract-test-generator) if you need support.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18354885",
+		"_collection_link": "https://postman.postman.co/workspace/Contract-Test-Generator---OAS3-~3740e38b-e23b-4a5e-a70e-abb476cff61e/collection/18354885-42982379-6212-43b9-a980-7f0354ea978c?action=share&source=collection_link&creator=18354885"
 	},
 	"item": [
 		{
@@ -189,27 +191,23 @@
 									"script": {
 										"exec": [
 											"//2024-06-07 - Added new environment variable for targeting specific API ID\r",
-											"let targetApiIds = pm.environment.get('env-apiIds');\r",
+											"let targetApiId = pm.environment.get('env-apiId');\r",
 											"let apiIds = [];\r",
 											"\r",
-											"if(targetApiIds && targetApiIds.length > 0) {\r",
+											"if(targetApiId && targetApiId != \"\") {\r",
 											"    //User has targeted at least 1 API in this workspace.\r",
-											"    targetApiIds = targetApiIds.split(\",\").map(function(item) {\r",
-											"        return item.trim();\r",
-											"    });\r",
+											"    targetApiId = targetApiId.trim();\r",
 											"\r",
 											"    //Validate that the API IDs provided exist in this workspace.\r",
 											"    let workspaceApiIds = pm.response.json().apis.map(api => api.id);\r",
 											"\r",
 											"    console.log(workspaceApiIds);\r",
 											"\r",
-											"    targetApiIds.forEach(targetApi => {\r",
-											"        pm.test(`Validate that API ${targetApi} exists in this workspace.`, function () {    \r",
-											"            pm.expect(workspaceApiIds, \"Your env-apiIds variable includes an invalid API ID\").to.include(targetApi);\r",
-											"        });\r",
-											"    })\r",
+											"    pm.test(`Validate that API ${targetApiId} exists in this workspace.`, function () {    \r",
+											"        pm.expect(workspaceApiIds, \"Your env-apiIds variable includes an invalid API ID\").to.include(targetApiId);\r",
+											"    });\r",
 											"\r",
-											"    apiIds = targetApiIds;\r",
+											"    apiIds = [targetApiId];\r",
 											"\r",
 											"    pm.test(`There is at least 1 API to process`, function() {\r",
 											"        pm.expect(apiIds).to.have.length.greaterThan(0);\r",
@@ -245,13 +243,11 @@
 								"header": [
 									{
 										"key": "X-Api-Key",
-										"value": "{{env-apiKey}}",
-										"type": "text"
+										"value": "{{env-apiKey}}"
 									},
 									{
 										"key": "Accept",
-										"value": "application/vnd.api.v10+json",
-										"type": "text"
+										"value": "application/vnd.api.v10+json"
 									}
 								],
 								"url": {
@@ -283,16 +279,42 @@
 									"script": {
 										"exec": [
 											"const jsonData = pm.response.json();\r",
+											"let latestVersionId;\r",
+											"let apiDefinitionId;\r",
 											"\r",
-											"pm.test('API has one or more versions', function(){\r",
-											"    pm.expect(jsonData).to.have.property('versions').and.to.be.an('array');\r",
-											"    pm.expect(jsonData.versions.length).to.be.above(0);\r",
-											"});\r",
+											"//set the latest version\r",
+											"if(jsonData && jsonData.versions && jsonData.versions.length > 0) {\r",
+											"    latestVersionId = jsonData.versions[0].id;\r",
+											"}\r",
 											"\r",
-											"const version = jsonData.versions[0];\r",
-											"pm.collectionVariables.set('coll-versionId', version.id);"
+											"if(latestVersionId) {\r",
+											"    pm.collectionVariables.set('coll-versionId', latestVersionId);\r",
+											"} \r",
+											"\r",
+											"//We have no published versions - see if we can get the schema via the supplied definitionId\r",
+											"apiId = pm.environment.get(\"env-apiId\");\r",
+											"apiDefinitionId = pm.environment.get(\"env-apiDefinitionId\");\r",
+											"\r",
+											"if(apiId && apiDefinitionId && apiId != \"\" && apiDefinitionId != \"\") {\r",
+											"    pm.collectionVariables.set(\"coll-schemaId\", apiDefinitionId);\r",
+											"    postman.setNextRequest(\"Get API Schema\");\r",
+											"}\r",
+											"\r",
+											"pm.test(\"API must have at least 1 version published or a definitionId provided.\", function() {\r",
+											"    postman.setNextRequest(null);\r",
+											"    pm.expect(latestVersionId || apiDefinitionId, \"API does not have a published version, and no definitionId is available in the environment\").to.not.be.undefined;\r",
+											"    \r",
+											"    console.log(apiDefinitionId)\r",
+											"\r",
+											"    if (apiDefinitionId) {\r",
+											"        postman.setNextRequest(\"Get API Schema\")\r",
+											"    } else if(latestVersionId) {\r",
+											"        postman.setNextRequest(\"Get Current API Schema\");\r",
+											"    }\r",
+											"})"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								},
 								{
@@ -313,7 +335,8 @@
 											"    postman.setNextRequest(null);\r",
 											"}"
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -325,13 +348,11 @@
 								"header": [
 									{
 										"key": "X-Api-Key",
-										"value": "{{env-apiKey}}",
-										"type": "text"
+										"value": "{{env-apiKey}}"
 									},
 									{
 										"key": "Accept",
-										"value": "application/vnd.api.v10+json",
-										"type": "text"
+										"value": "application/vnd.api.v10+json"
 									}
 								],
 								"url": {
@@ -401,13 +422,11 @@
 								"header": [
 									{
 										"key": "X-Api-Key",
-										"value": "{{env-apiKey}}",
-										"type": "text"
+										"value": "{{env-apiKey}}"
 									},
 									{
 										"key": "Accept",
-										"value": "application/vnd.api.v10+json",
-										"type": "text"
+										"value": "application/vnd.api.v10+json"
 									}
 								],
 								"url": {
@@ -481,13 +500,11 @@
 								"header": [
 									{
 										"key": "X-Api-Key",
-										"value": "{{env-apiKey}}",
-										"type": "text"
+										"value": "{{env-apiKey}}"
 									},
 									{
 										"key": "Accept",
-										"value": "application/vnd.api.v10+json",
-										"type": "text"
+										"value": "application/vnd.api.v10+json"
 									}
 								],
 								"url": {
@@ -1260,7 +1277,8 @@
 									"  return reference;  \r",
 									"}"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						},
 						{
@@ -1314,7 +1332,7 @@
 									"            const jsonData = pm.response.json();\r",
 									"            const schema = JSON.parse(pm.collectionVariables.get('coll-schema'));\r",
 									"            ajv.addSchema(schema, 'OAS');\r",
-									"            expectedResponse.schema.items.$ref = `OAS${expectedResponse.schema.items.$ref}`",
+									"            expectedResponse.schema.items.$ref = `OAS${expectedResponse.schema.items.$ref}`\r",
 									"            const valid = ajv.validate(expectedResponse.schema, jsonData);\r",
 									"            const errors = ajv.errorsText(valid.errors);\r",
 									"            pm.expect(errors).to.equal('No errors');\r",
@@ -1400,7 +1418,8 @@
 									"  return reference;  \r",
 									"}"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],

--- a/test/v2/contractTests-E2E-postman.js
+++ b/test/v2/contractTests-E2E-postman.js
@@ -51,15 +51,19 @@ describe('Postman Contract Test Suite - GET Requests', () => {
 
   describe('TEST002 - E2E test using Postman with API IDs specified', () => {
 
-    it('runs a contract test specifying a valid apiId', done => {
+    it('runs a contract test specifying a valid apiId & definitionId', done => {
       newman
         .run({
           collection: require('../../src/v2/Contract Test Generator.postman_collection.json'),
           environment: require('../../src/v2/OASv2.postman_environment.json'),
           envVar: [
             {
-              key: 'env-apiIds',
+              key: 'env-apiId',
               value: 'ac49b26e-12be-48c4-bf9d-fd7f6ec965b4'
+            },
+            {
+              key: 'env-apiDefinitionId',
+              value: 'aed01e51-1a12-4f6b-bba8-9a8061d65a55'
             }
           ]
         })
@@ -105,7 +109,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           environment: require('../../src/v2/OASv2.postman_environment.json'),
           envVar: [
             {
-              key: 'env-apiIds',
+              key: 'env-apiId',
               value: 'invalid'
             }
           ]

--- a/test/v3/contractTests-E2E-postman.js
+++ b/test/v3/contractTests-E2E-postman.js
@@ -58,8 +58,12 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           environment: require('../../src/v3/OASv3.postman_environment.json'),
           envVar: [
             {
-              key: 'env-apiIds',
+              key: 'env-apiId',
               value: '437ec72a-4d70-4a07-bd2f-83608cf95112'
+            },
+            {
+              key: "env-apiDefinitionId",
+              value: "c836684b-227a-4796-a9ef-8ec3e12d498d"
             }
           ]
         })
@@ -105,7 +109,7 @@ describe('Postman Contract Test Suite - GET Requests', () => {
           environment: require('../../src/v3/OASv3.postman_environment.json'),
           envVar: [
             {
-              key: 'env-apiIds',
+              key: 'env-apiId',
               value: 'invalid'
             }
           ]


### PR DESCRIPTION
Fix for previous PR #16.

**Breaking Change**

Postman V10 API endpoints require two parameters to retrieve the schema, apiId and apiDefinitionId. These need to be supplied from the user to enable the retrieval.

Alternatively, users can [publish a version](https://learning.postman.com/docs/designing-and-developing-your-api/versioning-an-api/api-versions/) of their API and the schema can be retrieved from the published version.

This fix enables the ability to add the new parameters as environment variables. 